### PR TITLE
Change link to live pip installation documenation

### DIFF
--- a/docs/kubos-sdk.md
+++ b/docs/kubos-sdk.md
@@ -23,7 +23,7 @@ The Kubos-SDK has been tested on Docker version 1.11.1.
 		$ sudo yum install python-pip python-wheel
 
 
-Other Linux Dristibutions see the  [pip installation guide](http://python-packaging-user-guide.readthedocs.io/en/latest/install_requirements_linux/)
+Other Linux Dristibutions see the  [pip installation guide](https://pip.pypa.io/en/stable/installing/)
 
 ##### Mac OS X
 


### PR DESCRIPTION
The current link in the docs is dead, This is a different link to pip docs on how to install pip.