### PR TITLE
KUBOS-153 Fixing Documentation Errors

### DIFF
--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -858,7 +858,7 @@ EXAMPLE_RECURSIVE      = NO
 # that contain images that are to be included in the documentation (see the
 # \image command).
 
-IMAGE_PATH             =
+IMAGE_PATH             = docs/images
 
 # The INPUT_FILTER tag can be used to specify a program that doxygen should
 # invoke to filter for each input file. Doxygen will invoke the filter program

--- a/docs/sdk-reference.md
+++ b/docs/sdk-reference.md
@@ -116,7 +116,7 @@ The next time your project is built it will use your local development module, r
 
  * You may now use the standard target command to select the newly linked target:
 
-        $ cdc ../<project-directory>/
+        $ cd ../<project-directory>/
         $ kubos target <target name>
 
 The next time your project is built it will use your local development target, rather than the packaged version.


### PR DESCRIPTION
Updated the Doxyfile IMAGE_PATH variable so that the images in docs/images will now be included during doc generation.

Also fixed a typo.