### PR TITLE
KUBOS-187 Adding Debug Configuration for the stm32f407 discovery target

### DIFF
--- a/targets/target-stm32f407-disco-gcc/openocd/flash.sh
+++ b/targets/target-stm32f407-disco-gcc/openocd/flash.sh
@@ -1,27 +1,40 @@
 #!/bin/bash
 
 this_dir=$(cd "`dirname "$0"`"; pwd)
-cmd=$1
+program=$1 # program is fist becasue for debugging there is not a command provided
+           # openocd will start a gdb server by default if there's not a command provided
+cmd=$2
+if [[ ! -z $cmd ]]; then
+    openocd_arg="$cmd $program"
+fi
 unamestr=`uname`
 
 if [[ "$unamestr" =~ "Linux" ]]; then
-	device=`lsusb -d '0483:'`
+    device=`lsusb -d '0483:'`
 elif [[ "$unamestr" =~ "Darwin" ]]; then
-	device=`python $this_dir/osxusb.py -d '0483:'`
+    device=`python $this_dir/osxusb.py -d '0483:'`
 fi
 
 if [[ "$device" =~ "3748" ]]; then
-	cfg="stm32f407vg.cfg"
+    cfg="stm32f407vg.cfg"
 fi
 
 if [[ "$device" =~ "374b" ]]; then
-	cfg="stm32f407g-disc1.cfg"
+    cfg="stm32f407g-disc1.cfg"
 fi
-
 
 if [[ ! -z $cfg ]]; then
-	echo openocd -f $this_dir/$cfg -c \"$cmd\"
-	openocd -f $this_dir/$cfg -c "$cmd"
+    if [[ ! -z $openocd_arg ]]; then #Flashing the target
+        echo openocd -f $this_dir/$cfg -c \"$openocd_arg\"
+        openocd -f $this_dir/$cfg -c "$openocd_arg"
+    else                            #Debugging the Target
+        (openocd -f $this_dir/$cfg -c "$openocd_arg" &) #Start the gdb server in a sub-shell
+        sleep 3
+        arm-none-eabi-gdb -ex "target remote localhost:3333" -ex "file $program"
+    fi
 else
-	echo "No compatible ST-Link device found"
+    echo "No compatible ST-Link device found"
 fi
+
+
+

--- a/targets/target-stm32f407-disco-gcc/openocd/flash.sh
+++ b/targets/target-stm32f407-disco-gcc/openocd/flash.sh
@@ -28,7 +28,8 @@ if [[ ! -z $cfg ]]; then
         echo openocd -f $this_dir/$cfg -c \"$openocd_arg\"
         openocd -f $this_dir/$cfg -c "$openocd_arg"
     else                            #Debugging the Target
-        (openocd -f $this_dir/$cfg -c "$openocd_arg" &) #Start the gdb server in a sub-shell
+        (pgrep openocd | xargs kill; #Try to kill any running open ocd instances
+         openocd -f $this_dir/$cfg -c "$openocd_arg" | /dev/null &) #Start the gdb server in a sub-shell
         sleep 3
         arm-none-eabi-gdb -ex "target remote localhost:3333" -ex "file $program"
     fi

--- a/targets/target-stm32f407-disco-gcc/openocd/flash.sh
+++ b/targets/target-stm32f407-disco-gcc/openocd/flash.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 this_dir=$(cd "`dirname "$0"`"; pwd)
-program=$1 # program is fist becasue for debugging there is not a command provided
+program=$1 # program is fist because for debugging there is not a command provided
            # openocd will start a gdb server by default if there's not a command provided
 cmd=$2
 if [[ ! -z $cmd ]]; then

--- a/targets/target-stm32f407-disco-gcc/target.json
+++ b/targets/target-stm32f407-disco-gcc/target.json
@@ -180,9 +180,8 @@
   ],
   "scripts": {
     "debug": [
-      "valinor",
-      "--target",
-      "stm32f407vg",
+      "bash",
+      "$PWD/yotta_targets/stm32f407-disco-gcc/openocd/flash.sh",
       "$program"
     ],
     "test": [
@@ -194,7 +193,8 @@
     "start": [
       "bash",
       "$PWD/yotta_targets/stm32f407-disco-gcc/openocd/flash.sh",
-      "stm32f4_flash $program"
+      "$program",
+      "stm32f4_flash"
     ]
   }
 }


### PR DESCRIPTION
Very basic debugging implementation for the stm32f4 discovery board.

I'm not crazy about the debugging implementation, specifically how openocd is started and not managed very well, or really at all by this implementation. It does work but should definitely be improved soon.
