### PR TITLE
Fix adding ppa -y option. Install correct arm-none-eabi toolchain.

### DIFF
--- a/vm/Vagrantfile
+++ b/vm/Vagrantfile
@@ -10,13 +10,13 @@ Vagrant.configure("2") do |config|
 
   config.vm.provision "shell", inline: %Q{
       apt-get update
-      add-apt-repository ppa:team-gcc-arm-embedded/ppa
-      add-apt-repository ppa:george-edison55/cmake-3.x
-      add-apt-repository ppa:git-core/ppa
+      add-apt-repository -y ppa:team-gcc-arm-embedded/ppa
+      add-apt-repository -y ppa:george-edison55/cmake-3.x
+      add-apt-repository -y ppa:git-core/ppa
       apt-get update
       apt-get -y install build-essential libssl-dev libffi-dev
       apt-get install -y python-setuptools build-essential ninja-build python-dev libffi-dev libssl-dev
-      apt-get install -y gcc-arm-none-eabi
+      apt-get install -y gcc-arm-embedded
       apt-get -y install python-pip
       apt-get -y install git
       apt-get install -y cmake


### PR DESCRIPTION
I messed up yesterday and switched to an incorrect version of the toolchain in the provisioning script. The missing -y option on the `add-apt-repository` command wasn't actually adding those repos for some reason (it was in the docker builds) and wasn't finding those packages as a result. This PR fixes that mistake and reverts to the correct toolchain package.