### PR TITLE
Basic telemetry implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,4 @@ upload.tar.gz
 # vim files
 .*.sw*
 vm/.vagrant/
+.vscode

--- a/telemetry/module.json
+++ b/telemetry/module.json
@@ -1,0 +1,13 @@
+{
+    "license":"Apache-2.0",
+    "name":"telemetry",
+    "version":"0.1.0",
+    "dependencies":{
+      "csp":"kubostech/libcsp"
+    },
+    "targetDependencies":{
+      "kubos-rt":{
+        "kubos-rt":"kubostech/kubos-rt"
+      }
+    }
+}

--- a/telemetry/source/telemetry.c
+++ b/telemetry/source/telemetry.c
@@ -1,0 +1,72 @@
+#ifdef YOTTA_CFG_TELEMETRY
+
+#include "telemetry/telemetry.h"
+#include <csp/csp.h>
+
+static void telemetry_publish(telemetry_packet packet);
+static void telemetry_publish_send(uint8_t port, telemetry_packet packet);
+
+/**
+ * Public facing telemetry input interface. Takes a telemetry_packet packet
+ * and passes it through the telemetry system.
+ *
+ * Currently just prints out the data passed in and passes it along to the publish interface. Start simple right?
+ */
+void telemetry_submit(telemetry_packet packet)
+{
+    printf("TELEM:%d:%d:%d\r\n", packet.source.source_id, packet.timestamp, packet.data);
+    telemetry_publish(packet);
+}
+
+/**
+ * This function represents the telemetry output/publish interface. The destination just needs to
+ * setup a csp connection on a port that telemetry connects to.
+ */
+static void telemetry_publish_send(uint8_t port, telemetry_packet packet)
+{
+    csp_packet_t * csp_packet;
+	csp_conn_t * conn;
+    csp_packet = csp_buffer_get(10);
+    if (csp_packet == NULL) {
+        /* Could not get buffer element */
+        printf("Failed to get buffer element\n");
+        return;
+    }
+
+    /* Connect to host HOST, port PORT with regular UDP-like protocol and 1000 ms timeout */
+    conn = csp_connect(CSP_PRIO_NORM, TELEMETRY_CSP_ADDRESS, port, 1000, CSP_O_NONE);
+    if (conn == NULL) {
+        /* Connect failed */
+        printf("Connection failed\n");
+        /* Remember to free packet buffer */
+        csp_buffer_free(csp_packet);
+        return;
+    }
+
+    memcpy(csp_packet->packet, &packet, sizeof(telemetry_packet));
+
+    /* Set packet length */
+    csp_packet->length = sizeof(telemetry_packet);
+
+    // /* Send packet */
+    if (!csp_send(conn, csp_packet, 1000)) {
+        /* Send failed */
+        printf("Send failed\n");
+        csp_buffer_free(csp_packet);
+    }
+    
+    csp_close(conn);
+}
+
+/**
+ * This function holds the master list of destinations interested in 
+ * telemetry data. The list here will be different for each project/binary..
+ */
+static void telemetry_publish(telemetry_packet packet)
+{
+    /** autogen list of ports which telem should publish to */
+    telemetry_publish_send(TELEMETRY_BEACON_PORT, packet);
+    telemetry_publish_send(TELEMETRY_HEALTH_PORT, packet);
+}
+
+#endif

--- a/telemetry/telemetry/destinations.h
+++ b/telemetry/telemetry/destinations.h
@@ -1,0 +1,20 @@
+#ifndef DESTINATIONS_H
+#define DESTINATIONS_H
+
+/**
+ * This file contains CSP ports and telemetry flags for routing to telemetry destinations.
+ * This file will be custom per the configuration of the current project
+ */
+
+/* Address used for the current CSP instance */
+#define TELEMETRY_CSP_ADDRESS 1
+
+/* Destination flags used in the telemetry_source structure */
+#define TELEMETRY_BEACON_FLAG 0x1
+#define TELEMETRY_HEALTH_FLAG 0x10
+
+/* CSP Ports used to send telemetry_packet information to destinations */
+#define TELEMETRY_BEACON_PORT 10
+#define TELEMETRY_HEALTH_PORT 11
+
+#endif

--- a/telemetry/telemetry/sources.h
+++ b/telemetry/telemetry/sources.h
@@ -1,0 +1,22 @@
+#ifndef SOURCES_H
+#define SOURCES_H
+
+#include "telemetry/telemetry.h"
+#include "telemetry/destinations.h"
+
+/**
+ * This file has telemetry data source/routing structures created for use
+ * by client code. This file will be custom based on the configuration of the project.
+ */
+
+/* The number of unique telemetry_source(s) points each destination will be receiving */ 
+#define TELEMETRY_NUM_BEACON 3
+#define TELEMETRY_NUM_HEALTH 2
+
+/* Structures representing telemetry_source(s) currently configured */ 
+static telemetry_source pos_x_source = { .source_id = 0, .dest_flag = TELEMETRY_BEACON_FLAG };
+static telemetry_source pos_y_source = { .source_id = 1, .dest_flag = TELEMETRY_BEACON_FLAG };
+static telemetry_source temp_source = { .source_id = 2, .dest_flag = TELEMETRY_HEALTH_FLAG };
+static telemetry_source gps_source = { .source_id = 3, .dest_flag = TELEMETRY_BEACON_FLAG | TELEMETRY_HEALTH_FLAG };
+
+#endif

--- a/telemetry/telemetry/telemetry.h
+++ b/telemetry/telemetry/telemetry.h
@@ -1,0 +1,32 @@
+#ifndef TELEMETRY_H
+#define TELEMETRY_H
+
+#include <stdint.h>
+
+/**
+ * Telemetry packet routing information structure
+ */
+typedef struct
+{
+    uint8_t source_id;
+    uint8_t dest_flag;
+} telemetry_source;
+
+/**
+ * Basic telemetry packet structure - encapsulating routing information
+ * and data.
+ */
+typedef struct
+{
+    telemetry_source source;
+    uint16_t timestamp;
+    uint16_t data;
+} telemetry_packet;
+
+/**
+ * Public facing telemetry input interface. Takes a telemetry_packet packet
+ * and passes it through the telemetry system.
+ */
+void telemetry_submit(telemetry_packet packet);
+
+#endif


### PR DESCRIPTION
* Initial implementation of basic core telemetry interfaces.
  * Single input interface
  * Mechanism for CSP publish/ouput
* Simple telemetry_packet with basic routing info and single data type
* Example header files defining source & destination information

/CC: @kubostech/devs 