### PR TITLE
Telemetry Data Type

### DIFF
--- a/telemetry/source/telemetry.c
+++ b/telemetry/source/telemetry.c
@@ -14,7 +14,12 @@ static void telemetry_publish_send(uint8_t port, telemetry_packet packet);
  */
 void telemetry_submit(telemetry_packet packet)
 {
-    printf("TELEM:%d:%d:%d\r\n", packet.source.source_id, packet.timestamp, packet.data);
+    if(packet.source.data_type == TELEMETRY_TYPE_INT) {
+        printf("TELEM:%d:%d:%d\r\n", packet.source.source_id, packet.timestamp, packet.data.i);
+    }
+    if(packet.source.data_type == TELEMETRY_TYPE_FLOAT) {
+        printf("TELEM:%d:%d:%f\r\n", packet.source.source_id, packet.timestamp, packet.data.f);
+    }
     telemetry_publish(packet);
 }
 

--- a/telemetry/source/telemetry.c
+++ b/telemetry/source/telemetry.c
@@ -75,3 +75,4 @@ static void telemetry_publish(telemetry_packet packet)
 }
 
 #endif
+

--- a/telemetry/source/telemetry.c
+++ b/telemetry/source/telemetry.c
@@ -75,4 +75,3 @@ static void telemetry_publish(telemetry_packet packet)
 }
 
 #endif
-

--- a/telemetry/telemetry/sources.h
+++ b/telemetry/telemetry/sources.h
@@ -14,9 +14,13 @@
 #define TELEMETRY_NUM_HEALTH 2
 
 /* Structures representing telemetry_source(s) currently configured */ 
-static telemetry_source pos_x_source = { .source_id = 0, .dest_flag = TELEMETRY_BEACON_FLAG };
-static telemetry_source pos_y_source = { .source_id = 1, .dest_flag = TELEMETRY_BEACON_FLAG };
-static telemetry_source temp_source = { .source_id = 2, .dest_flag = TELEMETRY_HEALTH_FLAG };
-static telemetry_source gps_source = { .source_id = 3, .dest_flag = TELEMETRY_BEACON_FLAG | TELEMETRY_HEALTH_FLAG };
+static telemetry_source pos_x_source = { .source_id = 0, 
+    .data_type = TELEMETRY_TYPE_FLOAT, .dest_flag = TELEMETRY_BEACON_FLAG };
+static telemetry_source pos_y_source = { .source_id = 1, 
+    .data_type = TELEMETRY_TYPE_FLOAT, .dest_flag = TELEMETRY_BEACON_FLAG };
+static telemetry_source temp_source = { .source_id = 2,
+    .data_type = TELEMETRY_TYPE_FLOAT, .dest_flag = TELEMETRY_HEALTH_FLAG };
+static telemetry_source gps_source = { .source_id = 3,
+    .data_type = TELEMETRY_TYPE_FLOAT, .dest_flag = TELEMETRY_BEACON_FLAG | TELEMETRY_HEALTH_FLAG };
 
 #endif

--- a/telemetry/telemetry/sources.h
+++ b/telemetry/telemetry/sources.h
@@ -24,4 +24,3 @@ static telemetry_source gps_source = { .source_id = 3,
     .data_type = TELEMETRY_TYPE_FLOAT, .dest_flag = TELEMETRY_BEACON_FLAG | TELEMETRY_HEALTH_FLAG };
 
 #endif
-

--- a/telemetry/telemetry/sources.h
+++ b/telemetry/telemetry/sources.h
@@ -24,3 +24,4 @@ static telemetry_source gps_source = { .source_id = 3,
     .data_type = TELEMETRY_TYPE_FLOAT, .dest_flag = TELEMETRY_BEACON_FLAG | TELEMETRY_HEALTH_FLAG };
 
 #endif
+

--- a/telemetry/telemetry/telemetry.h
+++ b/telemetry/telemetry/telemetry.h
@@ -48,3 +48,4 @@ typedef struct
 void telemetry_submit(telemetry_packet packet);
 
 #endif
+

--- a/telemetry/telemetry/telemetry.h
+++ b/telemetry/telemetry/telemetry.h
@@ -19,7 +19,7 @@ typedef struct
 typedef enum {
     TELEMETRY_TYPE_INT = 0,
     TELEMETRY_TYPE_FLOAT
-} telemetry_type;
+} telemetry_data_type;
 
 /**
  * Telemetry union for data.
@@ -28,7 +28,7 @@ typedef union
 {
     int i;
     float f;
-} telem_union;
+} telemetry_union;
 
 /**
  * Basic telemetry packet structure - encapsulating routing information
@@ -37,7 +37,7 @@ typedef union
 typedef struct
 {
     telemetry_source source;
-    telem_union data;
+    telemetry_union data;
     uint16_t timestamp;
 } telemetry_packet;
 

--- a/telemetry/telemetry/telemetry.h
+++ b/telemetry/telemetry/telemetry.h
@@ -4,13 +4,31 @@
 #include <stdint.h>
 
 /**
- * Telemetry packet routing information structure
+ * Telemetry packet routing information structure.
  */
 typedef struct
 {
     uint8_t source_id;
     uint8_t dest_flag;
+    uint8_t data_type;
 } telemetry_source;
+
+/**
+ * Telemetry data types.
+ */
+typedef enum {
+    TELEMETRY_TYPE_INT = 0,
+    TELEMETRY_TYPE_FLOAT
+} telemetry_type;
+
+/**
+ * Telemetry union for data.
+ */
+typedef union
+{
+    int i;
+    float f;
+} telem_union;
 
 /**
  * Basic telemetry packet structure - encapsulating routing information
@@ -19,8 +37,8 @@ typedef struct
 typedef struct
 {
     telemetry_source source;
+    telem_union data;
     uint16_t timestamp;
-    uint16_t data;
 } telemetry_packet;
 
 /**

--- a/telemetry/telemetry/telemetry.h
+++ b/telemetry/telemetry/telemetry.h
@@ -48,4 +48,3 @@ typedef struct
 void telemetry_submit(telemetry_packet packet);
 
 #endif
-


### PR DESCRIPTION
This PR adds a union data type to the telemetry packet struct and an enum for telemetry data types to allow destinations to decode which union member is being used. This is intended to start the discussion on the pros and cons of using a union to store telemetry data.

/cc @kubostech/devs 