### PR TITLE
Change to MSP430 linker map

### DIFF
--- a/targets/target-msp430f5529-gcc/ld/memory.x
+++ b/targets/target-msp430f5529-gcc/ld/memory.x
@@ -8,7 +8,7 @@ MEMORY {
   infoc            : ORIGIN = 0x1880, LENGTH = 0x0080 /* END=0x1900, size 128 */
   infob            : ORIGIN = 0x1900, LENGTH = 0x0080 /* END=0x1980, size 128 */
   infoa            : ORIGIN = 0x1980, LENGTH = 0x0080 /* END=0x1a00, size 128 */
-  ram (wx)         : ORIGIN = 0x1c00, LENGTH = 0x2800 /* END=0x4400, size 10K */
+  ram (wx)         : ORIGIN = 0x2400, LENGTH = 0x2000 /* END=0x4400, size 8K */
   rom (rx)         : ORIGIN = 0x4400, LENGTH = 0xbb80 /* END=0xff80, size 48000 */
   vectors          : ORIGIN = 0xff80, LENGTH = 0x0080 /* END=0x10000, size 128 as 64 2-byte segments */
   far_rom          : ORIGIN = 0x00010000, LENGTH = 0x00014400 /* END=0x00024400, size 81K */

--- a/targets/target-msp430f5529-gcc/ld/memory.x
+++ b/targets/target-msp430f5529-gcc/ld/memory.x
@@ -8,6 +8,7 @@ MEMORY {
   infoc            : ORIGIN = 0x1880, LENGTH = 0x0080 /* END=0x1900, size 128 */
   infob            : ORIGIN = 0x1900, LENGTH = 0x0080 /* END=0x1980, size 128 */
   infoa            : ORIGIN = 0x1980, LENGTH = 0x0080 /* END=0x1a00, size 128 */
+  usbram (wx)      : ORIGIN = 0x1c00, LENGTH = 0x0800 /* END=0x2400, size 2K */
   ram (wx)         : ORIGIN = 0x2400, LENGTH = 0x2000 /* END=0x4400, size 8K */
   rom (rx)         : ORIGIN = 0x4400, LENGTH = 0xbb80 /* END=0xff80, size 48000 */
   vectors          : ORIGIN = 0xff80, LENGTH = 0x0080 /* END=0x10000, size 128 as 64 2-byte segments */
@@ -15,11 +16,13 @@ MEMORY {
   /* Remaining banks are absent */
   ram2 (wx)        : ORIGIN = 0x0000, LENGTH = 0x0000
   ram_mirror (wx)  : ORIGIN = 0x0000, LENGTH = 0x0000
-  usbram (wx)      : ORIGIN = 0x0000, LENGTH = 0x0000
+  signature        : ORIGIN = 0x0000, LENGTH = 0x0000
 }
 REGION_ALIAS("REGION_TEXT", rom);
 REGION_ALIAS("REGION_DATA", ram);
-REGION_ALIAS("REGION_FAR_ROM", far_rom);
+REGION_ALIAS("REGION_FAR_ROM", far_rom); /* Legacy name, no longer used */
+REGION_ALIAS("REGION_FAR_TEXT", far_rom);
+REGION_ALIAS("REGION_FAR_DATA", ram2);
 PROVIDE (__info_segment_size = 0x80);
 PROVIDE (__infod = 0x1800);
 PROVIDE (__infoc = 0x1880);


### PR DESCRIPTION
A user recently encountered a linking error:
```
ym/freertos/existing/freertos.a(port.c.o): In function `prvTickISR':
/usr/lib/yotta_modules/freertos/FreeRTOS/Source/portable/GCC/MSP430F5529/port.c:346: relocation truncated to fit: R_MSP430_16_PCREL against symbol `usCriticalNesting' defined in .data.usCriticalNesting section in ym/freertos/existing/freertos.a(port.c.o)
```
This particular error is repeated across multiple functions. Don't get distracted by this error appearing to originate from the FreeRTOS code.

After digging around in the customer's code I found that I could make the linking errors go away once a certain amount of code was commented out. After adding back and commenting out code, trying to find problematic sections, it started to seem like the problem was more with the quantity of code. Adding back just a single do-nothing function would cause the linking error to get generated again. It was at this point that I started to suspect that the issue might lie with our compiling/linking process.

Some tinkering with the `memory.x` map in the msp430f5529 target led me to comparing it to the maps that ship with the toolchain. It looks like we have been using the 'nousb' version of the map which allocates 10kb of ram. I was able to get the customer's code compiling just fine using the default version of the map which allocates 8kb of ram and 2kb of "usbram". This 2kb of usb ram is sliced out of the front of the ram.

The interesting thing is that the usbram section starts where the ram used to start. Removing the usbram and resizing the ram to it's original origin/size causes the linking error to occur again. I'm not entirely sure what causes the original linking error **or** why moving the ram section causes it to go away. I am definitely not satisfied with this solution but it does seem to work for the moment.

Also interesting to note - the msp430f5529 launchpad actually only has 8kb of ram onboard - http://www.ti.com/tool/msp-exp430f5529lp.