### PR TITLE
[KUBOS-335] Kubus flash command for kubos-linux-isis-gcc target

### DIFF
--- a/targets/target-kubos-linux-isis-gcc/minicom/flash.sh
+++ b/targets/target-kubos-linux-isis-gcc/minicom/flash.sh
@@ -1,5 +1,18 @@
 #!/bin/bash
 # Copyright (C) 2016 Kubos Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 
 spinner() {
     local sp i n

--- a/targets/target-kubos-linux-isis-gcc/minicom/flash.sh
+++ b/targets/target-kubos-linux-isis-gcc/minicom/flash.sh
@@ -27,7 +27,7 @@ start=$(date +%s)
 
 this_dir=$(cd "`dirname "$0"`"; pwd)
 program=$1
-name=$(echo $1 | cut -d '/' -f 2)
+name=$(basename $1)
 
 password=$(cat yotta_config.json | python -c 'import sys,json; x=json.load(sys.stdin); print x["system"]["password"]')
 
@@ -43,7 +43,7 @@ if [[ "$device" =~ "6001" ]]; then
     spinner_pid=$!
     disown
 else
-    echo "No compatible FTDI device found"
+    echo "No compatible FTDI device found" 1>&2
     exit 0
 fi
 
@@ -80,13 +80,13 @@ minicom kubos -o -S send.tmp > flash.log
 
 # Check transfer result
 if grep -q incomplete flash.log; then
-    echo "Transfer Failed"
+    echo "Transfer Failed" 1>&2
 elif grep -q complete flash.log; then
     echo "Transfer Successful"
 elif grep -q incorrect flash.log; then
-    echo "Transfer Failed: Invalid password"
+    echo "Transfer Failed: Invalid password" 1>&2
 else
-    echo "Transfer Failed: Connection failed"
+    echo "Transfer Failed: Connection failed" 1>&2
 fi
 
 # Cleanup

--- a/targets/target-kubos-linux-isis-gcc/minicom/flash.sh
+++ b/targets/target-kubos-linux-isis-gcc/minicom/flash.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+# Copyright (C) 2016 Kubos Corporation
+
+this_dir=$(cd "`dirname "$0"`"; pwd)
+program=$1
+name=$(echo $1 | cut -d '/' -f 2)
+cmd=$2
+
+unamestr=`uname`
+
+if [[ "$unamestr" =~ "Linux" ]]; then
+    device=`lsusb -d '0403:'`
+fi
+
+if [[ "$device" =~ "6001" ]]; then
+    echo "Compatible FTDI device found"
+else
+    echo "No compatible FTDI device found"
+    exit 0
+fi
+
+# Setup serial connection configuration file
+# To-Do: Detect name of USB device to use (in case it's not USB0)
+cat > /etc/minicom/minirc.kubos <<-EOF
+pu port         /dev/ttyUSB0
+pu baudrate     115200
+pu bits         8
+pu parity       N
+pu stopbits     1
+pu rtscts       no
+EOF
+
+# Minicom doesn't allow any pass-through arguments, so instead we need to 
+# generate a script for it to run.
+# To-Do: Pass-through the root password.  There should be an update to 
+# make it more secure than 'password' at some point, likely to be set by
+# the user.
+cat > send.tmp <<-EOF
+verbose on
+send root
+expect {
+    "Password:" break
+    timeout 1 break
+}
+send password
+send "cd /usr/bin"
+send "rm $name"
+send "rz -bZ"
+! sz -b --zmodem $1
+send "exit"
+! killall -9 minicom
+EOF
+
+# Run the transfer script
+minicom kubos -o -S send.tmp
+
+# Cleanup
+rm send.tmp
+rm /etc/minicom/minirc.kubos
+stty sane

--- a/targets/target-kubos-linux-isis-gcc/minicom/flash.sh
+++ b/targets/target-kubos-linux-isis-gcc/minicom/flash.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (C) 2016 Kubos Corporation
+# Copyright (C) 2017 Kubos Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/targets/target-kubos-linux-isis-gcc/target.json
+++ b/targets/target-kubos-linux-isis-gcc/target.json
@@ -30,7 +30,7 @@
     },
     "system": {
       "password": "Kubos123"
-      }
+    }
   },
   "toolchain": "CMake/toolchain.cmake",
   "scripts": {

--- a/targets/target-kubos-linux-isis-gcc/target.json
+++ b/targets/target-kubos-linux-isis-gcc/target.json
@@ -29,5 +29,12 @@
       "arm": {}
     }
   },
-  "toolchain": "CMake/toolchain.cmake"
+  "toolchain": "CMake/toolchain.cmake",
+  "scripts": {
+    "start": [
+      "bash",
+      "$PWD/yotta_targets/kubos-linux-isis-gcc/minicom/flash.sh",
+      "$program"
+    ]
+  }
 }

--- a/targets/target-kubos-linux-isis-gcc/target.json
+++ b/targets/target-kubos-linux-isis-gcc/target.json
@@ -27,7 +27,10 @@
   "config": {
     "arch": {
       "arm": {}
-    }
+    },
+    "system": {
+      "password": "Kubos123"
+      }
   },
   "toolchain": "CMake/toolchain.cmake",
   "scripts": {


### PR DESCRIPTION
Created the script to transfer the compiled KubOS Linux user application onto the iOBC.
The application will be copied into /usr/bin, so that it will be located in $PATH and therefore executable from the command line.