### PR TITLE
[WIP] Turn on FATFS Thread Safe Option

### DIFF
--- a/kubos-core/kubos-core/modules/fatfs/ffconf.h
+++ b/kubos-core/kubos-core/modules/fatfs/ffconf.h
@@ -1,6 +1,8 @@
 /*---------------------------------------------------------------------------/
 /  FatFs - FAT file system module configuration file  R0.12  (C)ChaN, 2016
 /---------------------------------------------------------------------------*/
+#include <FreeRTOS.h>
+#include <semphr.h>
 
 #define _FFCONF 88100	/* Revision ID */
 
@@ -243,9 +245,9 @@
 /      lock control is independent of re-entrancy. */
 
 
-#define _FS_REENTRANT	0
+#define _FS_REENTRANT	1
 #define _FS_TIMEOUT		1000
-#define	_SYNC_t			HANDLE
+#define	_SYNC_t			xSemaphoreHandle
 /* The option _FS_REENTRANT switches the re-entrancy (thread safe) of the FatFs
 /  module itself. Note that regardless of this option, file access to different
 /  volume is always re-entrant and volume control functions, f_mount(), f_mkfs()

--- a/kubos-core/source/modules/fatfs/option/syscall.c
+++ b/kubos-core/source/modules/fatfs/option/syscall.c
@@ -1,0 +1,81 @@
+/*------------------------------------------------------------------------*/
+/* Sample code of OS dependent controls for FatFs                         */
+/* (C)ChaN, 2014                                                          */
+/*------------------------------------------------------------------------*/
+
+#include "kubos-core/modules/fatfs/ff.h"
+
+#if _FS_REENTRANT
+/*------------------------------------------------------------------------*/
+/* Create a Synchronization Object
+/*------------------------------------------------------------------------*/
+/* This function is called in f_mount() function to create a new
+/  synchronization object, such as semaphore and mutex. When a 0 is returned,
+/  the f_mount() function fails with FR_INT_ERR.
+*/
+
+int ff_cre_syncobj (    /* 1:Function succeeded, 0:Could not create the sync object */
+    BYTE vol,           /* Corresponding volume (logical drive number) */
+    _SYNC_t *sobj       /* Pointer to return the created sync object */
+)
+{
+    int ret;
+
+    *sobj = xSemaphoreCreateMutex();    /* FreeRTOS */
+    ret = (int)(*sobj != NULL);
+
+    return ret;
+}
+
+
+
+/*------------------------------------------------------------------------*/
+/* Delete a Synchronization Object                                        */
+/*------------------------------------------------------------------------*/
+/* This function is called in f_mount() function to delete a synchronization
+/  object that created with ff_cre_syncobj() function. When a 0 is returned,
+/  the f_mount() function fails with FR_INT_ERR.
+*/
+
+int ff_del_syncobj (    /* 1:Function succeeded, 0:Could not delete due to any error */
+    _SYNC_t sobj        /* Sync object tied to the logical drive to be deleted */
+)
+{
+    int ret;
+
+    vSemaphoreDelete(sobj);     /* FreeRTOS */
+    return 1;
+}
+
+
+
+/*------------------------------------------------------------------------*/
+/* Request Grant to Access the Volume                                     */
+/*------------------------------------------------------------------------*/
+/* This function is called on entering file functions to lock the volume.
+/  When a 0 is returned, the file function fails with FR_TIMEOUT.
+*/
+
+int ff_req_grant (  /* 1:Got a grant to access the volume, 0:Could not get a grant */
+    _SYNC_t sobj    /* Sync object to wait */
+)
+{
+    return (int)(xSemaphoreTake(sobj, _FS_TIMEOUT) == pdTRUE);	/* FreeRTOS */
+}
+
+
+
+/*------------------------------------------------------------------------*/
+/* Release Grant to Access the Volume                                     */
+/*------------------------------------------------------------------------*/
+/* This function is called on leaving file functions to unlock the volume.
+*/
+
+void ff_rel_grant (
+    _SYNC_t sobj    /* Sync object to be signaled */
+)
+{
+    xSemaphoreGive(sobj);   /* FreeRTOS */
+}
+
+#endif


### PR DESCRIPTION
:construction:
This PR turns on the thread safe option for the fatfs library (_FS_REENTRANT = 1) and implements the FreeRTOS synchronization object control functions.

TODO:
This requires more testing. I've been unable to generate an FR_TIMEOUT condition.
:construction: 