### PR TITLE
[KUBOS-365] Milestone 1 General Doc Updates

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1,151 +1,12 @@
-# Kubos CLI Command Reference
+# KubOS-SDK Command Reference
 
-## Common Commands
+## Creating a project
 
-[build](#building-a-project)
-
-[clean](#cleaning-a-project)
-
-[debug](#debugging-a-project)
-
-[init](#creating-a-project)
-
-[link](#linking-modules)
-
-[link-target](#linking-targets)
-
-[list || ls](#listing-dependencies)
-
-[start || flash](#flashing-a-project)
-
-[target](#selecting-a-target)
-
-[update](#updating-kubos)
-
-[version](#checking-the-kubos-version)
-
-## Other Commands
-
-[config](#checking-a-configuration)
-
-[licenses](#displaying-licenses)
-
-[outdated](#checking-for-old-modules)
-
-[remove](#removing-dependency-files)
-
-[shrinkwrap](#freezing-dependency-versions)
-
-[test](#testing-a-project)
-
-[use](#updating-kubos)
-
-[versions](#listing-available-kubos-versions)
-
-
-## Building a Project
-
-    kubos build [-h] [--config path/to/config.json] [-g] [-r] [-d]
-                     [-G CMAKE_GENERATOR]
-                     [MODULE_TO_BUILD [MODULE_TO_BUILD ...]]
-                     
-The programs or libraries to build can be specified (by default only the libraries needed by the current module and the current module's own tests are built). For example, to build the tests of all dependencies, run:
-  yotta build all_tests
-
-Positional arguments:
-
-    MODULE_TO_BUILD       List modules or programs to build (omit to build the default set, or use "all_tests" to build all tests, including those of dependencies).
-
-Optional arguments:
-
-    -h, --help            show help message
-    --config path/to/config.json
-                        Specify the path to a JSON configuration file to extend the build configuration provided by the target
-    -g, --generate-only   Only generate CMakeLists, don't run CMake or build
-    -r, --release-build
-    -d, --debug-build
-    -G CMAKE_GENERATOR, --cmake-generator CMAKE_GENERATOR
-                            CMake generator to use (defaults to Ninja). You can use this to generate IDE project files instead, see cmake --help for possible generator names. Note that only Ninja or Unix Makefile based generators will work correctly with yotta.
-
-
-To build a Kubos project, all we need to do is run the `kubos build` command. The Kubos CLI will read the module.json file, determine what libraries are needed and build them.
-
-Basic build command:
-
-        $ kubos build
-
-Build with verbose output:
-
-        $ kubos build -- -v
-        
-(Options can be passed to the underlying build tool by passing them after --)
-
-## Cleaning a Project
-
-    kubos clean [-h]
-
-Optional arguments:
-    
-    -h, --help  show help message
-
-This command removes the build folder that is created with `kubos build` so that a completely fresh build can then be created.
-
-## Checking a Configuration
-
-    kubos config [-h] [--config path/to/config.json] [--plain]
-                    [--colourful]
-
-Optional arguments:
-
-    -h, --help            show help message
-    --config path/to/config.json
-                           Specify the path to a JSON configuration file to extend the build configuration provided by the target
-    --plain               Use a simple output format with no colours.
-    --colourful           Force colourful output, even if the output is not to a tty.
-
-If you want to see what options your project is being built with, run the `kubos config` command.  It will display the combined JSON values of both the default configuration for the target and any user configuration options specified in the project's config.json file.
-
-## Debugging a Project
-
-    kubos debug [-h] [--config path/to/config.json] [program]
-
-Positional arguments:
-
-    program               name of the program to be debugged
-
-Optional arguments:
-
-    -h, --help            show help message
-    --config path/to/config.json
-                        Specify the path to a JSON configuration file to extend the build configuration provided by the target.
-
-A gdb server must be started to allow your gdb instance to connect and debug directly on your hardware device.
-After building your project with `kubos build` the Kubos CLI can start a gdb server and gdb instance for you.
-
-Start a gdb server and instance:
-Note: this may need to run as root depending on your usb device permissions
-
-        $ kubos debug
-
-
-## Creating a Project
-
-    kubos init [-h] [-l | -r] proj_name
-    
-Positional arguments:
-
-    proj_name    specify the project name
-
-Optional arguments:
-
-      -h, --help   show help message
-      -l, --linux  Initialize Kubos SDK project for KubOS Linux
-      -r, --rt     Initialize Kubos SDK project for KubOS RT
-
-
-Run the `kubos init` command followed by the name of your project to bootstrap your Kubos project. This will create a new directory under your current working directory with your project's name and add the source files for a basic Kubos project (kubos-rt-example).
+Run the `kubos init` command followed by the name of your project to bootstrap your KubOS project. This will create a new directory under your current working directory with your project's name and add the source files for a basic KubOS project (kubos-rt-example).
 
         $ kubos init project-name
+
+Note - Inside of the build system there are several reserved words, a project cannot be named any of these words. These are `test`, `source`, `include`, `yotta_modules` and `yotta_targets`.
 
 The contents of your project directory should look something like this:
 
@@ -162,226 +23,11 @@ Here is a quick rundown of the files that were generated:
 | `module.json` | This file is yotta's module description file |
 
 
-Kubos uses the yotta build/module system, which is where this file structure comes from. You can read more about yotta [here](http://yottadocs.mbed.com/).
+KubOS uses the yotta build/module system, which is where this file structure comes from. You can read more about yotta [here](http://yottadocs.mbed.com/).
 
-### Note: Reserved Project Names
+## Selecting a target
 
-Inside of the build system there are several reserved words which cannot be used as the Kubos project name:
-
-- `test`
-- `source`
-- `include`
-- `yotta_modules`
-- `yotta_targets`
-
-## Displaying Licenses
-
-    kubos licenses [-h] [--all]
-    
-optional arguments:
-
-    -h, --help  show help message
-    --all, -a   List all licenses, not just each unique license.
-
-If you'd like to see which licenses Kubos is currently using, you can use the `kubos licenses` command.
-
-## Linking Modules
-
-    kubos link [-h] [-a] [module_or_path]
-
-Positional arguments:
-    
-    module_or_path  Link a globally installed (or globally linked) module into the current module's dependencies. If ommited, globally link the current module.
-
-Optional arguments:
-
-    -h, --help      show help message
-    -a, --all       Link all modules (and targets) from the global cache into the local project.
-
-Links are made in two steps - first globally then locally.
-
-By linking a module globally you are making it available to link into any of your projects. By linking the module locally you are including the linked module in your build.
-
-**Note:** In order to be able to be linked, the module must have a module.json file.
-
-To link a module globally:
-
-        $ cd .../<module-directory>/
-        $ kubos link
-
-To link a module that is already globally linked into a project:
-
-        $ cd .../<project-directory>/
-        $ kubos link <module name>
-
-The next time your project is built it will use your local development module, rather than the packaged version.
-
-To verify where all of your targets are being loaded from `kubos list` will show you which modules are linked and which are local to your project
-
-## Linking Targets
-
-    kubos link-target [-h] [target_or_path]
-    
-Positional arguments:
-
-    target_or_path  Link a globally installed (or globally linked) target into the current target's dependencies. If ommited, globally link the current target.
-
-Optional arguments:
-
-    -h, --help      show help message
-
-Custom or modified targets are linked in a very similar way to modules.
-
-Links are made in two steps - first globally then locally.
-
-By linking a target globally you are making it available to link into any of your projects. By linking the target locally you are now able to use the linked target in your build.
-
-To link a target globally:
-
-        $ cd .../<target-directory>/
-        $ kubos link-target
-
-To link a target that is already globally linked into a project:
-
-        $ cd .../<project-directory>/
-        $ kubos link-target <target name>
-
-You may now use the standard target command to select the newly linked target:
-
-        $ cd ../<project-directory>/
-        $ kubos target <target name>
-
-The next time your project is built it will use your local development target, rather than the packaged version.
-
-Running `kubos target` will show you whether you are using a local or a linked copy of a target
-
-## Listing Dependencies
-
-    kubos list [-h] [--config path/to/config.json] [--all]
-                  [--display-origin] [--json]
-                  
-    kubos ls [-h] [--config path/to/config.json] [--all]
-                  [--display-origin] [--json]
-
-Optional arguments:
-
-    -h, --help            show help message
-    --config path/to/config.json
-                            Specify the path to a JSON configuration file to extend the build configuration provided by the target
-    --all, -a             Show all dependencies (including repeats, and test-only dependencies)
-    --display-origin, -i  Display where modules were originally downloaded from (implied by --all).
-    --json, -j            Output json representation of dependencies (implies --all).
-
-Use the `kubos list` command to see a project's dependencies.  These are derived from the project's module.json "dependencies" section and the dependency sections of each of those modules and so forth.
-This command is also useful for seeing the source folder for each dependency and whether or not an external location is being used for a dependency of the project.
-
-## Checking for Old Modules
-
-    kubos outdated [-h]
-
-Optional arguments:
-
-    -h, --help  show help message
-
-Display information about dependencies which have newer versions available.
-
-## Removing Dependency Files
-
-    kubos remove [-h] [<module>]
-    
-Positional arguments:
-
-    <module>    Name of the module to remove. If omitted the current module or target will be removed from the global linking directory.
-
-Optional arguments:
-
-    -h, --help  show help message
-
-Remove the downloaded version of a dependency module or target, or un-link a linked module or target. This command does not remove the dependency as a requirement for your project.
-In order to remove the dependency entirely, you'll need to update the module.json file and remove the module from the dependencies list.
-
-## Freezing Dependency Versions
-
-    kubos shrinkwrap [-h]
-
-Optional arguments:
-
-    -h, --help  show help message
-
-Create a yotta-shrinkwrap.json file to freeze dependency versions.
-
-## Testing a Project
-
-    kubos test [-h] [--config path/to/config.json] [--list] [--no-build]
-                  [-r] [-d] [-G CMAKE_GENERATOR]
-                  [TEST_TO_RUN [TEST_TO_RUN ...]]
-
-Positional arguments:
-    
-    TEST_TO_RUN           List tests to run (omit to run the default set, or use "all" to run all).
-
-Optional arguments:
-
-    -h, --help            show help message
-    --config path/to/config.json
-                            Specify the path to a JSON configuration file to extend the build configuration provided by the target
-    --list, -l            List the tests that would be run, but don't run them. Implies --no-build
-    --no-build, -n        Don't build first.
-    -r, --release-build
-    -d, --debug-build
-    -G CMAKE_GENERATOR, --cmake-generator CMAKE_GENERATOR
-                            CMake generator to use (defaults to Ninja). You can use this to generate IDE project files instead, see cmake --help for possible generator names
-                                    
-Run the tests for the current module on the current target. A build will be run first, and options to the build subcommand are also accepted by test.
-This subcommand requires the target to provide a "test" script that will be used to run each test. Modules may also define a "testReporter" script, which will be piped the output from each test, and may produce a summary.
-
-
-## Flashing a Project
-
-
-    kubos start [-h] [--config path/to/config.json] [program]
-    kubos flash [-h] [--config path/to/config.json] [program]
-    
-Positional arguments:
-
-    program               name of the program to be started
-
-Optional arguments:
-
-    -h, --help            show help message
-    --config path/to/config.json
-                        Specify the path to a JSON configuration file to extend the build configuration provided by the target
-
-
-Flashing your project using the kubos tool is a relatively straightforward process:
-
-1. Ensure that your board is plugged into your computer
-
-TODO: We probably want to add some info here on Virtualbox device filters and Guest Additions issues
-
-2. Run the flash command
-
-        $ kubos flash
-
-*Note: If your current user does not have read/write permission to your hardware device you may need to run this command as root*
-
-        $ sudo kubos flash
-        
-        
-## Selecting a Target
-
-    kubos target [-h] [-l] [set_target]
-
-Positional arguments:
-    
-    set_target  set a new target board or display the current target
-
-Optional arguments:
-  
-    -h, --help  show help message
-    -l, --list  List all of the available target names
-
-The Kubos SDK needs to know which target you intend to build for so it can select the proper cross compiler. Kubos currently supports several different targets:
+Yotta needs to know which target you intend to build for so it can select the proper cross compiler. KubOS currently supports several different targets:
 
 | MCU Family   | Board  |
 | ------------- |-------------|
@@ -407,62 +53,96 @@ The respective commands to select those targets are as follows.
 To see all of the available targets run:
 
         $ kubos target --list
-        
-To see the currently set target run `kubos target` without any additional parameters.
 
-## Updating Kubos
+## Building a project
 
-    kubos update [-h] [set_version]
-    kubos use [-h] (-b BRANCH | set_version)
-    
-Positional arguments:
+To build a KubOS project, all we need to do is run the `kubos build` command. The Kubos-cli (really `yotta` under the covers) will read the module.json file, determine what libraries are needed and build them.
 
-    set_version  Specify a version of the kubos source to use.
+Basic build command:
 
-Optional arguments:
+        $ kubos build
 
-    -h, --help   show help message
-    -b BRANCH, --branch BRANCH
-                        Set the branch flag to specify to checkout a branch, not a tag
-    
-The Kubos is under constant development.  It's possible, and quite likely, that at some point a vagrant image might contain an outdated version of the Kubos repos.
+Build with verbose output:
 
-In order to upgrade to the latest version, you can use the `kubos update` command.  If, instead, you'd like to downgrade to an older version, you can use the `set_version` positional parameter.
+        $ kubos build -- -v
 
-For example:
+Clean command:
 
-    $ kubos update v0.0.1
-    
-Use the `kubos use` command upgrade to an experimental version of Kubos.  For example:
+        $ kubos clean
 
-    $ kubos use test-branch
-    
-This command will load the test-branch branch from the kubos repo
-    
-Use the `kubos version` command to see which version you're currently using and the `kubos versions` command to see what versions are available.
+## Linking local modules & targets
 
-## Checking the Kubos Version
+The Kubos-cli comes with all of the latest KubOS modules and targets pre-packaged and pre-linked. If a module or target needs to be modified locally, the cli comes with the ability to link that local module into the build process.
 
-    kubos version [-h] [-l]
+##### Linking modules:
 
-Optional arguments:
-    
-    -h, --help  show help message
-    -l, --list  List all of the locally available KubOS source versions
+ * Links are made in two steps - first globally then locally.
 
-Displays the current active version of the Kubos CLI and Kubos source repo.
+ * By linking a module globally you are making it available to link into any of your projects. By linking the module locally you are including the linked module in your build.
 
-## Listing Available Kubos Versions
+ * To link a module globally:
 
-    kubos versions [-h]
+        $ cd .../<module-directory>/
+        $ kubos link
 
-Optional arguments:
-    
-    -h, --help  show help message
-    
-Display the available versions of the KubOS source.
+ * To link a module that is already globally linked into a project:
 
+        $ cd .../<project-directory>/
+        $ kubos link <module name>
 
+The next time your project is built it will use your local development module, rather than the packaged version.
 
-        
+Note: To verify where all of your targets are being loaded from `kubos list` will show you which modules are linked and which are local to your project
 
+##### Linking targets:
+
+ * Custom or modified targets are linked in a very similar way to modules.
+
+ * Links are made in two steps - first globally then locally.
+
+ * By linking a target globally you are making it available to link into any of your projects. By linking the target locally you are now able to use the linked target in your build.
+
+ * To link a target globally:
+
+        $ cd .../<target-directory>/
+        $ kubos link-target
+
+ * To link a target that is already globally linked into a project:
+
+        $ cd .../<project-directory>/
+        $ kubos link-target <target name>
+
+ * You may now use the standard target command to select the newly linked target:
+
+        $ cd ../<project-directory>/
+        $ kubos target <target name>
+
+The next time your project is built it will use your local development target, rather than the packaged version.
+
+Note: Running `kubos target` will show you whether you are using a local or a linked copy of a target
+
+## Flashing your project
+
+Flashing your project using the kubos tool is a relatively straightforward process:
+
+1. Ensure that your board is plugged into your computer
+
+TODO: We probably want to add some info here on Virtualbox device filters and Guest Additions issues
+
+2. Run the flash command
+
+        $ kubos flash
+
+*Note: If your current user does not have read/write permission to your hardware device you may need to run this command as root*
+
+        $ sudo kubos flash
+
+#### Debug your project
+
+A gdb server must be started to allow your gdb instance to connect and debug directly on your hardware device.
+After building your project with `kubos build` the kubos-cli can start a gdb server and gdb instance for you.
+
+Start a gdb server and instance:
+Note: this may need to run as root depending on your usb device permissions
+
+        $ kubos debug

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1,12 +1,151 @@
-# KubOS-SDK Command Reference
+# Kubos CLI Command Reference
 
-## Creating a project
+## Common Commands
 
-Run the `kubos init` command followed by the name of your project to bootstrap your KubOS project. This will create a new directory under your current working directory with your project's name and add the source files for a basic KubOS project (kubos-rt-example).
+[build](#building-a-project)
+
+[clean](#cleaning-a-project)
+
+[debug](#debugging-a-project)
+
+[init](#creating-a-project)
+
+[link](#linking-modules)
+
+[link-target](#linking-targets)
+
+[list || ls](#listing-dependencies)
+
+[start || flash](#flashing-a-project)
+
+[target](#selecting-a-target)
+
+[update](#updating-kubos)
+
+[version](#checking-the-kubos-version)
+
+## Other Commands
+
+[config](#checking-a-configuration)
+
+[licenses](#displaying-licenses)
+
+[outdated](#checking-for-old-modules)
+
+[remove](#removing-dependency-files)
+
+[shrinkwrap](#freezing-dependency-versions)
+
+[test](#testing-a-project)
+
+[use](#updating-kubos)
+
+[versions](#listing-available-kubos-versions)
+
+
+## Building a Project
+
+    kubos build [-h] [--config path/to/config.json] [-g] [-r] [-d]
+                     [-G CMAKE_GENERATOR]
+                     [MODULE_TO_BUILD [MODULE_TO_BUILD ...]]
+                     
+The programs or libraries to build can be specified (by default only the libraries needed by the current module and the current module's own tests are built). For example, to build the tests of all dependencies, run:
+  yotta build all_tests
+
+Positional arguments:
+
+    MODULE_TO_BUILD       List modules or programs to build (omit to build the default set, or use "all_tests" to build all tests, including those of dependencies).
+
+Optional arguments:
+
+    -h, --help            show help message
+    --config path/to/config.json
+                        Specify the path to a JSON configuration file to extend the build configuration provided by the target
+    -g, --generate-only   Only generate CMakeLists, don't run CMake or build
+    -r, --release-build
+    -d, --debug-build
+    -G CMAKE_GENERATOR, --cmake-generator CMAKE_GENERATOR
+                            CMake generator to use (defaults to Ninja). You can use this to generate IDE project files instead, see cmake --help for possible generator names. Note that only Ninja or Unix Makefile based generators will work correctly with yotta.
+
+
+To build a Kubos project, all we need to do is run the `kubos build` command. The Kubos CLI will read the module.json file, determine what libraries are needed and build them.
+
+Basic build command:
+
+        $ kubos build
+
+Build with verbose output:
+
+        $ kubos build -- -v
+        
+(Options can be passed to the underlying build tool by passing them after --)
+
+## Cleaning a Project
+
+    kubos clean [-h]
+
+Optional arguments:
+    
+    -h, --help  show help message
+
+This command removes the build folder that is created with `kubos build` so that a completely fresh build can then be created.
+
+## Checking a Configuration
+
+    kubos config [-h] [--config path/to/config.json] [--plain]
+                    [--colourful]
+
+Optional arguments:
+
+    -h, --help            show help message
+    --config path/to/config.json
+                           Specify the path to a JSON configuration file to extend the build configuration provided by the target
+    --plain               Use a simple output format with no colours.
+    --colourful           Force colourful output, even if the output is not to a tty.
+
+If you want to see what options your project is being built with, run the `kubos config` command.  It will display the combined JSON values of both the default configuration for the target and any user configuration options specified in the project's config.json file.
+
+## Debugging a Project
+
+    kubos debug [-h] [--config path/to/config.json] [program]
+
+Positional arguments:
+
+    program               name of the program to be debugged
+
+Optional arguments:
+
+    -h, --help            show help message
+    --config path/to/config.json
+                        Specify the path to a JSON configuration file to extend the build configuration provided by the target.
+
+A gdb server must be started to allow your gdb instance to connect and debug directly on your hardware device.
+After building your project with `kubos build` the Kubos CLI can start a gdb server and gdb instance for you.
+
+Start a gdb server and instance:
+Note: this may need to run as root depending on your usb device permissions
+
+        $ kubos debug
+
+
+## Creating a Project
+
+    kubos init [-h] [-l | -r] proj_name
+    
+Positional arguments:
+
+    proj_name    specify the project name
+
+Optional arguments:
+
+      -h, --help   show help message
+      -l, --linux  Initialize Kubos SDK project for KubOS Linux
+      -r, --rt     Initialize Kubos SDK project for KubOS RT
+
+
+Run the `kubos init` command followed by the name of your project to bootstrap your Kubos project. This will create a new directory under your current working directory with your project's name and add the source files for a basic Kubos project (kubos-rt-example).
 
         $ kubos init project-name
-
-Note - Inside of the build system there are several reserved words, a project cannot be named any of these words. These are `test`, `source`, `include`, `yotta_modules` and `yotta_targets`.
 
 The contents of your project directory should look something like this:
 
@@ -23,11 +162,226 @@ Here is a quick rundown of the files that were generated:
 | `module.json` | This file is yotta's module description file |
 
 
-KubOS uses the yotta build/module system, which is where this file structure comes from. You can read more about yotta [here](http://yottadocs.mbed.com/).
+Kubos uses the yotta build/module system, which is where this file structure comes from. You can read more about yotta [here](http://yottadocs.mbed.com/).
 
-## Selecting a target
+### Note: Reserved Project Names
 
-Yotta needs to know which target you intend to build for so it can select the proper cross compiler. KubOS currently supports several different targets:
+Inside of the build system there are several reserved words which cannot be used as the Kubos project name:
+
+- `test`
+- `source`
+- `include`
+- `yotta_modules`
+- `yotta_targets`
+
+## Displaying Licenses
+
+    kubos licenses [-h] [--all]
+    
+optional arguments:
+
+    -h, --help  show help message
+    --all, -a   List all licenses, not just each unique license.
+
+If you'd like to see which licenses Kubos is currently using, you can use the `kubos licenses` command.
+
+## Linking Modules
+
+    kubos link [-h] [-a] [module_or_path]
+
+Positional arguments:
+    
+    module_or_path  Link a globally installed (or globally linked) module into the current module's dependencies. If ommited, globally link the current module.
+
+Optional arguments:
+
+    -h, --help      show help message
+    -a, --all       Link all modules (and targets) from the global cache into the local project.
+
+Links are made in two steps - first globally then locally.
+
+By linking a module globally you are making it available to link into any of your projects. By linking the module locally you are including the linked module in your build.
+
+**Note:** In order to be able to be linked, the module must have a module.json file.
+
+To link a module globally:
+
+        $ cd .../<module-directory>/
+        $ kubos link
+
+To link a module that is already globally linked into a project:
+
+        $ cd .../<project-directory>/
+        $ kubos link <module name>
+
+The next time your project is built it will use your local development module, rather than the packaged version.
+
+To verify where all of your targets are being loaded from `kubos list` will show you which modules are linked and which are local to your project
+
+## Linking Targets
+
+    kubos link-target [-h] [target_or_path]
+    
+Positional arguments:
+
+    target_or_path  Link a globally installed (or globally linked) target into the current target's dependencies. If ommited, globally link the current target.
+
+Optional arguments:
+
+    -h, --help      show help message
+
+Custom or modified targets are linked in a very similar way to modules.
+
+Links are made in two steps - first globally then locally.
+
+By linking a target globally you are making it available to link into any of your projects. By linking the target locally you are now able to use the linked target in your build.
+
+To link a target globally:
+
+        $ cd .../<target-directory>/
+        $ kubos link-target
+
+To link a target that is already globally linked into a project:
+
+        $ cd .../<project-directory>/
+        $ kubos link-target <target name>
+
+You may now use the standard target command to select the newly linked target:
+
+        $ cd ../<project-directory>/
+        $ kubos target <target name>
+
+The next time your project is built it will use your local development target, rather than the packaged version.
+
+Running `kubos target` will show you whether you are using a local or a linked copy of a target
+
+## Listing Dependencies
+
+    kubos list [-h] [--config path/to/config.json] [--all]
+                  [--display-origin] [--json]
+                  
+    kubos ls [-h] [--config path/to/config.json] [--all]
+                  [--display-origin] [--json]
+
+Optional arguments:
+
+    -h, --help            show help message
+    --config path/to/config.json
+                            Specify the path to a JSON configuration file to extend the build configuration provided by the target
+    --all, -a             Show all dependencies (including repeats, and test-only dependencies)
+    --display-origin, -i  Display where modules were originally downloaded from (implied by --all).
+    --json, -j            Output json representation of dependencies (implies --all).
+
+Use the `kubos list` command to see a project's dependencies.  These are derived from the project's module.json "dependencies" section and the dependency sections of each of those modules and so forth.
+This command is also useful for seeing the source folder for each dependency and whether or not an external location is being used for a dependency of the project.
+
+## Checking for Old Modules
+
+    kubos outdated [-h]
+
+Optional arguments:
+
+    -h, --help  show help message
+
+Display information about dependencies which have newer versions available.
+
+## Removing Dependency Files
+
+    kubos remove [-h] [<module>]
+    
+Positional arguments:
+
+    <module>    Name of the module to remove. If omitted the current module or target will be removed from the global linking directory.
+
+Optional arguments:
+
+    -h, --help  show help message
+
+Remove the downloaded version of a dependency module or target, or un-link a linked module or target. This command does not remove the dependency as a requirement for your project.
+In order to remove the dependency entirely, you'll need to update the module.json file and remove the module from the dependencies list.
+
+## Freezing Dependency Versions
+
+    kubos shrinkwrap [-h]
+
+Optional arguments:
+
+    -h, --help  show help message
+
+Create a yotta-shrinkwrap.json file to freeze dependency versions.
+
+## Testing a Project
+
+    kubos test [-h] [--config path/to/config.json] [--list] [--no-build]
+                  [-r] [-d] [-G CMAKE_GENERATOR]
+                  [TEST_TO_RUN [TEST_TO_RUN ...]]
+
+Positional arguments:
+    
+    TEST_TO_RUN           List tests to run (omit to run the default set, or use "all" to run all).
+
+Optional arguments:
+
+    -h, --help            show help message
+    --config path/to/config.json
+                            Specify the path to a JSON configuration file to extend the build configuration provided by the target
+    --list, -l            List the tests that would be run, but don't run them. Implies --no-build
+    --no-build, -n        Don't build first.
+    -r, --release-build
+    -d, --debug-build
+    -G CMAKE_GENERATOR, --cmake-generator CMAKE_GENERATOR
+                            CMake generator to use (defaults to Ninja). You can use this to generate IDE project files instead, see cmake --help for possible generator names
+                                    
+Run the tests for the current module on the current target. A build will be run first, and options to the build subcommand are also accepted by test.
+This subcommand requires the target to provide a "test" script that will be used to run each test. Modules may also define a "testReporter" script, which will be piped the output from each test, and may produce a summary.
+
+
+## Flashing a Project
+
+
+    kubos start [-h] [--config path/to/config.json] [program]
+    kubos flash [-h] [--config path/to/config.json] [program]
+    
+Positional arguments:
+
+    program               name of the program to be started
+
+Optional arguments:
+
+    -h, --help            show help message
+    --config path/to/config.json
+                        Specify the path to a JSON configuration file to extend the build configuration provided by the target
+
+
+Flashing your project using the kubos tool is a relatively straightforward process:
+
+1. Ensure that your board is plugged into your computer
+
+TODO: We probably want to add some info here on Virtualbox device filters and Guest Additions issues
+
+2. Run the flash command
+
+        $ kubos flash
+
+*Note: If your current user does not have read/write permission to your hardware device you may need to run this command as root*
+
+        $ sudo kubos flash
+        
+        
+## Selecting a Target
+
+    kubos target [-h] [-l] [set_target]
+
+Positional arguments:
+    
+    set_target  set a new target board or display the current target
+
+Optional arguments:
+  
+    -h, --help  show help message
+    -l, --list  List all of the available target names
+
+The Kubos SDK needs to know which target you intend to build for so it can select the proper cross compiler. Kubos currently supports several different targets:
 
 | MCU Family   | Board  |
 | ------------- |-------------|
@@ -53,96 +407,62 @@ The respective commands to select those targets are as follows.
 To see all of the available targets run:
 
         $ kubos target --list
+        
+To see the currently set target run `kubos target` without any additional parameters.
 
-## Building a project
+## Updating Kubos
 
-To build a KubOS project, all we need to do is run the `kubos build` command. The Kubos-cli (really `yotta` under the covers) will read the module.json file, determine what libraries are needed and build them.
+    kubos update [-h] [set_version]
+    kubos use [-h] (-b BRANCH | set_version)
+    
+Positional arguments:
 
-Basic build command:
+    set_version  Specify a version of the kubos source to use.
 
-        $ kubos build
+Optional arguments:
 
-Build with verbose output:
+    -h, --help   show help message
+    -b BRANCH, --branch BRANCH
+                        Set the branch flag to specify to checkout a branch, not a tag
+    
+The Kubos is under constant development.  It's possible, and quite likely, that at some point a vagrant image might contain an outdated version of the Kubos repos.
 
-        $ kubos build -- -v
+In order to upgrade to the latest version, you can use the `kubos update` command.  If, instead, you'd like to downgrade to an older version, you can use the `set_version` positional parameter.
 
-Clean command:
+For example:
 
-        $ kubos clean
+    $ kubos update v0.0.1
+    
+Use the `kubos use` command upgrade to an experimental version of Kubos.  For example:
 
-## Linking local modules & targets
+    $ kubos use test-branch
+    
+This command will load the test-branch branch from the kubos repo
+    
+Use the `kubos version` command to see which version you're currently using and the `kubos versions` command to see what versions are available.
 
-The Kubos-cli comes with all of the latest KubOS modules and targets pre-packaged and pre-linked. If a module or target needs to be modified locally, the cli comes with the ability to link that local module into the build process.
+## Checking the Kubos Version
 
-##### Linking modules:
+    kubos version [-h] [-l]
 
- * Links are made in two steps - first globally then locally.
+Optional arguments:
+    
+    -h, --help  show help message
+    -l, --list  List all of the locally available KubOS source versions
 
- * By linking a module globally you are making it available to link into any of your projects. By linking the module locally you are including the linked module in your build.
+Displays the current active version of the Kubos CLI and Kubos source repo.
 
- * To link a module globally:
+## Listing Available Kubos Versions
 
-        $ cd .../<module-directory>/
-        $ kubos link
+    kubos versions [-h]
 
- * To link a module that is already globally linked into a project:
+Optional arguments:
+    
+    -h, --help  show help message
+    
+Display the available versions of the KubOS source.
 
-        $ cd .../<project-directory>/
-        $ kubos link <module name>
 
-The next time your project is built it will use your local development module, rather than the packaged version.
 
-Note: To verify where all of your targets are being loaded from `kubos list` will show you which modules are linked and which are local to your project
+        
 
-##### Linking targets:
-
- * Custom or modified targets are linked in a very similar way to modules.
-
- * Links are made in two steps - first globally then locally.
-
- * By linking a target globally you are making it available to link into any of your projects. By linking the target locally you are now able to use the linked target in your build.
-
- * To link a target globally:
-
-        $ cd .../<target-directory>/
-        $ kubos link-target
-
- * To link a target that is already globally linked into a project:
-
-        $ cd .../<project-directory>/
-        $ kubos link-target <target name>
-
- * You may now use the standard target command to select the newly linked target:
-
-        $ cd ../<project-directory>/
-        $ kubos target <target name>
-
-The next time your project is built it will use your local development target, rather than the packaged version.
-
-Note: Running `kubos target` will show you whether you are using a local or a linked copy of a target
-
-## Flashing your project
-
-Flashing your project using the kubos tool is a relatively straightforward process:
-
-1. Ensure that your board is plugged into your computer
-
-TODO: We probably want to add some info here on Virtualbox device filters and Guest Additions issues
-
-2. Run the flash command
-
-        $ kubos flash
-
-*Note: If your current user does not have read/write permission to your hardware device you may need to run this command as root*
-
-        $ sudo kubos flash
-
-#### Debug your project
-
-A gdb server must be started to allow your gdb instance to connect and debug directly on your hardware device.
-After building your project with `kubos build` the kubos-cli can start a gdb server and gdb instance for you.
-
-Start a gdb server and instance:
-Note: this may need to run as root depending on your usb device permissions
-
-        $ kubos debug

--- a/docs/contribution-process.md
+++ b/docs/contribution-process.md
@@ -148,7 +148,7 @@ that you ran into while working on your code changes).
 - Click 'Create pull request'
 
 If you'd like specific people to review your code, you can either mention them in the description with an '@{name}' tag, or by adding them 
-to the 'Assignees' list.
+to the 'Reviewers' list.
 
 ## Merge in New Changes From Master
 

--- a/docs/contribution-process.md
+++ b/docs/contribution-process.md
@@ -82,7 +82,7 @@ To create your own repo:
 - If you see a dialog 'Where should we fork this repository?', click the icon with your username.
 - Within your development environment, create a link to your new remote repository:
 
-    $ git remote add {repo name you create} {personal repo url} 
+    $ git remote add {remote name you create} {personal repo url} 
 	
 Clone the repo that you want to modify onto your local machine
         
@@ -125,9 +125,9 @@ Commit your changes and push to your remote branch (the branch will be created a
 
 	$ git add {files you changed}
 	$ git commit -m "Descriptive message about the changes you made"
-	$ git push {repo name} {local branch name}
+	$ git push {remote name} {local branch name}
 	
-If you're committing against a kubostech repo, then the repo name will likely be "origin".  If you're committing against your personal fork, then the repo name
+If you're committing against a kubostech repo, then the remote name will likely be "origin".  If you're committing against your personal fork, then the remote name
 will match what you specified in the `git remote add` command.
 	
 [Commit early, commit often](http://www.databasically.com/2011/03/14/git-commit-early-commit-often/)
@@ -178,7 +178,7 @@ Push the resolved changed to your remote repo
 
 	$ git add {fixed files}
 	$ git commit
-	$ git push origin {local branch name}
+	$ git push {remote name} {local branch name}
 
 If you navigate to your pull request, you should now see that github says "This branch has no conflicts with the base branch", indicating that
 the changes okay to merge (pending pull request approval).

--- a/docs/contribution-process.md
+++ b/docs/contribution-process.md
@@ -5,7 +5,7 @@ This is the workflow you should go through in order to create and complete a tas
 0. [Sign the CLA](#sign-the-cla)
 1. [Create a JIRA Issue](#create-a-jira-issue)
 2. [Mark the Issue as 'In Progress'](#mark-the-issue-as-in-progress)
-3. [Create a Personal Copy of the Code You Want to Work On](#create-a-personal-copy-of-the-code-you-want-to-work-on)
+3. [Create a Branch of the Code You Want to Work On](#create-a-branch-of-the-code-you-want-to-work-on)
 4. [Make Your Changes](#make-your-changes)
 5. [Create a Pull Request](#create-a-pull-request)
 6. [Merge in New Changes From Master](#merge-in-new-changes-from-master)
@@ -33,6 +33,7 @@ If one doesn't exist, you should create it:
 - The 'Component/s' field should be updated, if possible, to list the related area/s affected by this issue.
 - The description should go into more detail about what the problem/feature is and what needs to be done in order
 to complete the task.
+    * If you are creating a story, the description should follow the [Agile user story template](https://www.mountaingoatsoftware.com/agile/user-stories)
 - If you're creating a bug, update the 'Affects Version/s' field to document the oldest affected version of the project
 
 If you want to create an issue but not immediately work on it, the description field should be an in-depth summary of the problem/feature
@@ -51,25 +52,21 @@ In order to track what's being worked on and by whom, for every issue you work y
 	* From the full issue description page, click the 'In Progress' button
 	* From the 'Active Sprints' page, drag the issue from the 'To-Do' column into the 'In Progress' column
 	
-## Create a Personal Copy of the Code You Want to Work On
+## Create a Branch of the Code You Want to Work On
 
-All code changes should initially be made in your own personal repo and then be submitted against the main code repo as a pull request.
-
-To create your own repo:
-- Navigate to the github page of the main code that you want to work on.  For example, https://github.com/kubostech/kubos-sdk.
-- Click the 'Fork' button in the upper right-hand corner.
-- If you see a dialog 'Where should we fork this repository?', click the icon with your username.
-- Within your development environment, create a link to your new remote repository:
-
-	$ git remote add {repo name you create} {personal repo url}
+All code changes should initially be made in a branch of the relavent Kubos repo and then be submitted against the master branch as a pull request:
 	
-You'll also want to create a local branch to work on inside of your development environment.
+Clone the repo that you want to modify onto your local machine
+        
+    $ git clone http://github.com/kubostech/kubos
+    
+Move into the repo folder
 
-From the project folder where you'll be making changes:
+    $ cd kubos
+    
+Create a local branch to make your changes
 
-	$ git checkout -b {local branch name you create}
-
-You will need to fork each repository where you will be making changes.
+    $ git checkout -b {local branch name you create}
 
 ## Make Your Changes
 
@@ -96,11 +93,11 @@ for a certain board type, you would edit kubos-hal/kubos-hal/uart.h in the appro
 Add or update any unit tests that are affected by your changes.  For instance, if support for i2c slave mode is added for the STM32F4 board, then the
 kubos-hal-stm32f4/test/i2c.c file's test\_i2c\_slave test case should be updated to test the successful execution of the board in slave mode.
 
-Commit your changes and push to your remote repository:
+Commit your changes and push to your remote branch (the branch will be created automatically if it doesn't exist):
 
 	$ git add {files you changed}
 	$ git commit -m "Descriptive message about the changes you made"
-	$ git push {repo name} {local branch name}
+	$ git push origin {local branch name}
 	
 [Commit early, commit often](http://www.databasically.com/2011/03/14/git-commit-early-commit-often/)
 
@@ -109,7 +106,7 @@ Commit your changes and push to your remote repository:
 Once all of your changes for an issue have been completed, you should create a pull request in order to bring the changes into the main code's
 master branch.  You will need to create a pull request for each repository you are making changes to.
 
-From the github page for your personal repository that contains the changes you want to merge:
+From the github page for the repository that contains the changes you want to merge:
 - Click the 'Branch:' dropdown on the left-hand side and select the local branch containing your changes
 - Click the 'New pull request' button
 - The title of the pull request should be the JIRA issue number followed by a descriptive title
@@ -119,6 +116,8 @@ but it's also good to mention things like documentation updates and any miscella
 that you ran into while working on your code changes).
 - Click 'Create pull request'
 
+If you'd like specific people to review your code, you can either mention them in the description with an '@{name}' tag, or by adding them 
+to the 'Assignees' list.
 
 ## Merge in New Changes From Master
 
@@ -130,10 +129,10 @@ In order to resolve the conflict, execute the following steps within your develo
 
 Merge the master branch into your local branch
 
-	$ git checkout kubostech/master
-	$ git pull kubostech master
+	$ git checkout origin/master
+	$ git pull origin master
 	$ git checkout {local branch where your changes are}
-	$ git merge kubostech/master
+	$ git merge origin/master
 
 Git will edit any files with conflicts.  Conflicts will look like this:
 	
@@ -148,17 +147,19 @@ Push the resolved changed to your remote repo
 
 	$ git add {fixed files}
 	$ git commit
-	$ git push {repo name} {local branch name}
+	$ git push origin {local branch name}
 
 If you navigate to your pull request, you should now see that github says "This branch has no conflicts with the base branch", indicating that
 the changes okay to merge (pending pull request approval).
 
 ## Wait for Pull Request Approval
 
+Move the JIRA issue to 'Reviewing' to indicate that the work is done, pending approval.
+
 Once your pull request has been submitted, it must be approved by at least one person before the request can be merged into the master branch.
 Once it has been approved, you can go to your pull request page and then click the 'Merge' button.
 - Note:  If your changes have been approved, but you don't see a 'Merge' button, you likely don't have permission to merge for that project. 
-Talk to Ryan Plauche.
+Talk to Ryan Plauche (ryan@kubos.co).
 
 In all likelyhood, you'll need to make changes to your code before your pull request can be merged.  Make the changes in your local development 
 environment and then commit and push them into your remote repo.  As long as you're still using the same local branch, these new changes will
@@ -176,5 +177,5 @@ Before you mark the issue as done, verify the following:
 Update the issue's 'Fix version' field to reflect the version that these changes are being implemented in.
 
 Once all of the work for the issue has been completed, you can mark the issue as Done in one of two ways:
-- From the full issue description page, click the 'In Progress' button
-- From the 'Active Sprints' page, drag the issue from the 'To-Do' column into the 'In Progress' column
+- From the full issue description page, click the 'Done' button
+- From the 'Kanban Board' page, drag the issue from the 'Reviewing' column into the 'Done' column

--- a/docs/contribution-process.md
+++ b/docs/contribution-process.md
@@ -1,9 +1,9 @@
-# KubOS Contribution Process
+# Kubos Contribution Process
 
 This is the workflow you should go through in order to create and complete a task to contribute to the KubOS project
 
 0. [Sign the CLA](#sign-the-cla)
-1. [Create a JIRA Issue](#create-a-jira-issue)
+1. [Create an Issue](#create-an-issue)
 2. [Mark the Issue as 'In Progress'](#mark-the-issue-as-in-progress)
 3. [Create a Branch of the Code You Want to Work On](#create-a-branch-of-the-code-you-want-to-work-on)
 4. [Make Your Changes](#make-your-changes)
@@ -19,11 +19,19 @@ main codebase.
 
 The KubOS CLA can be found [here](https://www.clahub.com/agreements/kubostech/KubOS).
 
-## Create a JIRA Issue
+## Create an Issue
 
-Everything you work on should have a corresponding JIRA issue.  
+Everything you work on should have a corresponding JIRA issue.  Community members might not have access to JIRA and should then create a Github issue instead.  
 
-If one doesn't exist, you should create it:
+If one doesn't exist, you should create it.
+
+If you want to create an issue but not immediately work on it, the description field should be an in-depth summary of the problem/feature
+and what needs to be changed.  Ideally, you, or whoever works the issue, should be able to read the description and understand what work 
+needs to be done without talking to whoever created the issue (though talking to the creator is still recommended in order to make sure that
+the requirements are well understood and haven't changed since the issue was created).
+
+### JIRA
+
 - Click the 'Create' button at the top of the JIRA page
 - Project should be 'KubOS'
 - Issue type should be 'Story' or 'Bug'
@@ -36,25 +44,45 @@ to complete the task.
     * If you are creating a story, the description should follow the [Agile user story template](https://www.mountaingoatsoftware.com/agile/user-stories)
 - If you're creating a bug, update the 'Affects Version/s' field to document the oldest affected version of the project
 
-If you want to create an issue but not immediately work on it, the description field should be an in-depth summary of the problem/feature
-and what needs to be changed.  Ideally, you, or whoever works the issue, should be able to read the description and understand what work 
-needs to be done without talking to whoever created the issue (though talking to the creator is still recommended in order to make sure that
-the requirements are well understood and haven't changed since the issue was created).
+### Github
+
+- Navigate to the repo you'd like to open an issue against (most likely kubostech/kubos)
+- Click the 'Issues' tab
+- Click the 'New Issue' button
+- The title should be a descriptive overview of the problem
+- The description should go into more detail about what the problem/feature is and what needs to be done in order
+to complete the task.
+    * If you are creating a story, the description should follow the [Agile user story template](https://www.mountaingoatsoftware.com/agile/user-stories)
+- Click the 'Labels' link and add a tag for 'Bug' or 'Enhancement' depending on what kind of work should be done
+
 
 ## Mark the Issue as 'In Progress'
 
 In order to track what's being worked on and by whom, for every issue you work you should:
-- Drag the issue from the backlog into the sprint (if it's not already present)
+- JIRA: Drag the issue from the backlog into the sprint (if it's not already present)
 - Assign it to yourself
-	* Click the issue
-	* Under 'People'>'Assignee', click 'Assign to me'
-- Mark the issue as 'In Progress'.  There are two ways:
-	* From the full issue description page, click the 'In Progress' button
-	* From the 'Active Sprints' page, drag the issue from the 'To-Do' column into the 'In Progress' column
+    * Click the issue
+    * JIRA: Under 'People'>'Assignee', click 'Assign to me'
+    * Github: Click the 'Assignees' link and select yourself
+- Mark the issue as 'In Progress'.  
+    * JIRA: There are two ways
+        + From the full issue description page, click the 'In Progress' button
+        + From the 'Active Sprints' page, drag the issue from the 'To-Do' column into the 'In Progress' column
+    * Github: Edit the title of the project and add "[WIP]"
 	
 ## Create a Branch of the Code You Want to Work On
 
-All code changes should initially be made in a branch of the relavent Kubos repo and then be submitted against the master branch as a pull request:
+All code changes should initially be made in a branch of the relavent Kubos repo either in the main repo, or in a personal copy (if you don't have access)
+ and then be submitted against the master branch as a pull request:
+ 
+To create your own repo:
+
+- Navigate to the github page of the main code that you want to work on.  For example, https://github.com/kubostech/kubos.
+- Click the 'Fork' button in the upper right-hand corner.
+- If you see a dialog 'Where should we fork this repository?', click the icon with your username.
+- Within your development environment, create a link to your new remote repository:
+
+    $ git remote add {repo name you create} {personal repo url} 
 	
 Clone the repo that you want to modify onto your local machine
         
@@ -97,7 +125,10 @@ Commit your changes and push to your remote branch (the branch will be created a
 
 	$ git add {files you changed}
 	$ git commit -m "Descriptive message about the changes you made"
-	$ git push origin {local branch name}
+	$ git push {repo name} {local branch name}
+	
+If you're committing against a kubostech repo, then the repo name will likely be "origin".  If you're committing against your personal fork, then the repo name
+will match what you specified in the `git remote add` command.
 	
 [Commit early, commit often](http://www.databasically.com/2011/03/14/git-commit-early-commit-often/)
 

--- a/docs/first-project.md
+++ b/docs/first-project.md
@@ -1,14 +1,14 @@
-# Getting started with KubOS-SDK
+# Getting started with Kubos SDK
 
-This is intended to be a quick guide to creating a new project on top of the Kubos framework.
+This is intended to be a quick guide to creating a new KubOS RT project on top of the Kubos framework.
 
 ## Prerequisites
 
-[Install the KubOS-CLI](docs/cli-installing.md)
+[Install the Kubos SDK](docs/cli-installing.md)
 
 Create an instance of the Kubos Vagrant box
 
-        $ vagrant init kubostech/kubos-sdk
+        $ vagrant init kubostech/kubos-dev
 
 Start the box
 
@@ -20,27 +20,14 @@ SSH into your box
 
 ## Creating your project
 
-It is strongly recommended that you create your project in a directory on your host that is shared with your box, rather than directly inside your box. If the
-directory is located on your host, if your box is ever destroyed or re-built your project files will be completely intact.
+The simplest way to create a new Kubos project is by using the Kubos CLI. The `kubos init` command takes a project name and creates the project files and folders.
 
-By default the directory that you run `vagrant init kubostech/kubos-sdk` in will be mounted into the box at the path `/vagrant`
-
-To mount a specific directory from your host, open the Vagrantfile and look for the following two lines:
-
-        #To mount a specific directory into your box uncomment the next line and change the following paths to match your host directory and a desired mount point in the box.
-        #config.vm.synced_folder "/path/on/host", "/path/in/vagrant/box"
-
-Un-comment the second line and change the paths to match your host directory and a desired mount point in the box. Note - These must be absolute paths.
-
-For more information on mounting volumes see the following [guide](https://www.vagrantup.com/docs/synced-folders/basic_usage.html)
-
-The simplest way to create a new Kubos project is by using the kubos-cli. The `kubos init` command takes a project name and creates the project files & folder.
+**Note:** Inside of the build system there are several reserved words, a project cannot be named any of these words. The most common of these are `test`, `source` and `include`.
 
         $ kubos init myproject
 
 The init command creates a new directory with the kubos-rt-example included so you can get started right away.
 
-Note - Inside of the build system there are several reserved words, a project cannot be named any of these words. The most common of these are `test`, `source` and `include`.
 
 We have also created several different example Kubos projects which can be used as starting points.
 
@@ -49,10 +36,13 @@ We have also created several different example Kubos projects which can be used 
  - [Example showing the spi HAL and sensors](https://github.com/kubostech/kubos-spi-example)
  - [Example showing the sensor interface](https://github.com/kubostech/kubos-sensor-example)
  - [Example showing csp over uart](https://github.com/kubostech/kubos-csp-example)
+ - [Example KubOS Linux project](https://github.com/kubostech/kubos-linux-example)
 
 If you would prefer to use one of our other examples as a starting point all you need to do is run:
 
-        $ git clone https://github.com/kubos-rt-example myproject
+        $ git clone https://github.com/kubos-spi-example myproject
+        
+It is unnecessary to run the `kubos init` command in this case.
 
 ## Choosing a target
 
@@ -80,4 +70,4 @@ Note - You may need to run this command with `sudo` if you run into a permission
 
         $ sudo kubos flash
 
-Congratulations! You have just created a basic KubOS project, built it and (hopefully) flashed it onto some hardware.
+Congratulations! You have just created a basic Kubos project, built it and (hopefully) flashed it onto some hardware.

--- a/docs/kubos-development.md
+++ b/docs/kubos-development.md
@@ -1,35 +1,108 @@
-# Developing KubOS Modules
+# Developing Kubos Modules
 
 The top level [Kubos](https://github.com/kubostech/kubos) project contains all of the kubos source modules and targets.
 
-## Getting started - Modifying an existing Kubos module
+## Getting Started
 
-1. [Install the latest version of Kubos-CLI](docs/sdk-installing.md)
-2. Clone the Kubos repo
+If you want to make changes to the Kubos code, perhaps for debugging purposes or to support a new peripheral, you'll first need to clone the kubos 
+repo and then pass the folder through to your VM:
 
-        $ git clone https://github.com/kubostech/kubos
+[Install the latest version of the Kubos SDK](docs/sdk-installing.md)
 
-## Kubos development environment
+Clone the Kubos repo to your host machine.
 
-Kubos is a collection of Yotta modules and targets which are loaded inside the kubos-sdk Vagrant box. They can also be built locally using the `kubos link` and `kubos link-target`
-commands.
+    $ git clone https://github.com/kubostech/kubos
+        
+Update your Vagrantfile to pass the repo folder through to your VM.  The destination folder will be created if it doesn't already exist.
 
-### Building an example application
+    config.vm.synced_folder "C:\\Users\\Catherine\\git\\kubos", "/home/vagrant/shared"
+    
+Reload your vagrant image to pick up the new synced folder.
 
-Several different example applications can be found in the Kubos Example repos. Any of these can be easily built using the CLI.
+    $ vagrant reload
 
-        $ kubos init <project_name> #will initialize a new project with the [kubos-rt-example project](https://github.com/kubostech/kubos-rt-example)
-        $ kubos target msp430f5529-gcc
-        $ kubos build
+Log in to your vagrant image
 
-### Linking in a local module
+    $ vagrant ssh       
+    
+**Note:** It is possible to do development on the kubos repo from within the vagrant image, but it is our recommended workflow to have the repo on
+your host machine and pass it through.  This way if the image becomes corrupted, or if you want to pass the modified code through to another VM, it's
+still available.
 
-Made some modifications to an existing module? Want to link in a new library? The kubos-cli can help with that as well.
+## Kubos Development Environment
 
-        $ cd /home/kubos/super-awesome-space-library
-        $ sudo kubos link
-        $ cd /home/kubos/example
-        $ kubos link super-awesome-space-library
-        $ kubos build
+The kubos repository is a collection of [Yotta](http://yottadocs.mbed.com/) modules and targets which are loaded inside the Kubos Vagrant box. They can also be built 
+locally using the `kubos link` and `kubos link-target` commands.
+
+See the [quick start guide](docs/first-project.md) for instructions on setting up and building Kubos SDK projects.
+
+### Linking in a Local Module
+
+Once you've made changes to your local kubos repo, you'll want to link them into your project.
+
+**Note:** If you create a new high-level component, like telemetry or hal, you'll need to create a module.json file so that the module can be linked in
+successfully.
+
+Let's say that you've updated the Kubos telemetry module to add debugging lines to see how the flow of communication works between processes.  This would
+be your process to link and build the changes:
+
+    $ cd /home/vagrant/shared/telemetry
+    $ kubos link
+    $ cd /home/vagrant/my-project
+    $ kubos link telemetry
+    $ kubos build
 
 After running the `kubos link` command from the module directory and `kubos link <module name>` from the project directory, `kubos build` will pick up the module and pull it into the build process.
+
+**Note:** The module name is taken from the "name" definition in the module.json file, not from the folder name.  For example, to link in the CSP module, you would do `kubos link csp`, not `kubos link libcsp`. 
+
+### Linking in a Local Target
+
+If you want to add or update a Kubos target, you'll follow a similar process.  For example:
+
+    $ cd /home/vagrant/shared/targets/target-stm32f407-disco-gcc
+    $ kubos link-target
+    $ cd /home/vagrant/my-project
+    $ kubos link-target stm32f407-disco-gcc
+    $ kubos build
+    
+**Note:** The target name is taken from the "name" definition in the target.json file, not from the folder name.
+    
+### Unlinking Modules and Targets
+
+If you'd like to unlink your local changes and revert to using the official Kubos version, use the `kubos unlink` and `kubos unlink-target` commands from within your project
+
+    $ cd /home/vagrant/my-project
+    $ kubos unlink telemetry
+    $ kubos unlink stm32f407-disco-gcc
+    
+### Listing Linked Resources
+
+To see what the dependencies of your project are and which folders are currently being used to build, use the `kubos ls` command.  
+
+Any modules which have be linked from an outside resource will show that file path.  Any modules which are using the native Kubos code will have a '/home/vagrant/.kubos' path.
+
+    vagrant@vagrant:~/my-project$ kubos ls
+    my-project 0.1.0
+    ┗━ kubos-rt 0.1.0 yotta_modules/kubos-rt -> /home/vagrant/sharedOS/kubos-rt
+    ┣━ freertos 9.0.4 yotta_modules/freertos -> /home/vagrant/.kubos/kubos/freertos/os
+    ┃   ┣━ cmsis-core 1.2.4 yotta_modules/cmsis-core -> /home/vagrant/.kubos/kubos/cmsis/cmsis-core
+    ┃   ┃   ┗━ cmsis-core-st 1.0.5 yotta_modules/cmsis-core-st -> /home/vagrant/.kubos/kubos/cmsis/cmsis-core-st
+    ┃   ┃          ┗━ cmsis-core-stm32f4 1.2.4 yotta_modules/cmsis-core-stm32f4 -> /home/vagrant/.kubos/kubos/cmsis/cmsis-core-stm32f4
+    ┃   ┃              ┣━ stm32cubef4 1.2.4 yotta_modules/stm32cubef4 -> /home/vagrant/.kubos/kubos/hal/stm32cubef4
+    ┃   ┃              ┃   ┗━ stm32cubef4-stm32f407vg 0.0.3 yotta_modules/stm32cubef4-stm32f407vg -> /home/vagrant/.kubos/kubos/hal/stm32cubef4-stm32f407vg
+    ┃   ┃              ┗━ cmsis-core-stm32f407xg 0.0.4 yotta_modules/cmsis-core-stm32f407xg -> /home/vagrant/.kubos/kubos/cmsis/cmsis-core-stm32f407xg
+    ┃   ┗━ freertos-config-stm32f4 0.0.3 yotta_modules/freertos-config-stm32f4 -> /home/vagrant/.kubos/kubos/freertos/config-stm32f4
+    ┣━ csp 1.5.1 yotta_modules/csp -> /home/vagrant/sharedOS/libcsp
+    ┣━ kubos-hal 0.1.2 yotta_modules/kubos-hal -> /home/vagrant/.kubos/kubos/hal/kubos-hal
+    ┃   ┗━ kubos-hal-stm32f4 0.1.2 yotta_modules/kubos-hal-stm32f4 -> /home/vagrant/.kubos/kubos/hal/kubos-hal-stm32f4
+    ┗━ kubos-core 0.1.2 yotta_modules/kubos-core -> /home/vagrant/.kubos/kubos/kubos-core
+
+Similarly, to see the dependencies of your target and any linked resources, use the `kubos target` command.
+
+    vagrant@vagrant:~/my-project$ kubos target
+    stm32f407-disco-gcc 0.1.0 -> /home/vagrant/sharedOS/targets/target-stm32f407-disco-gcc
+    kubos-arm-none-eabi-gcc 0.1.1 -> /home/vagrant/.kubos/kubos/targets/target-kubos-arm-none-eabi-gcc
+    kubos-rt-gcc 0.1.0 -> /home/vagrant/.kubos/kubos/targets/target-kubos-rt-gcc
+    kubos-gcc 0.1.1 -> /home/vagrant/.kubos/kubos/targets/target-kubos-gcc
+

--- a/docs/kubos-development.md
+++ b/docs/kubos-development.md
@@ -1,6 +1,6 @@
 # Developing Kubos Modules
 
-The top level [Kubos](https://github.com/kubostech/kubos) project contains all of the kubos source modules and targets.
+The top level [Kubos](https://github.com/kubostech/kubos) project contains all of the Kubos source modules and targets.
 
 ## Getting Started
 

--- a/docs/kubos-linux-on-iobc.md
+++ b/docs/kubos-linux-on-iobc.md
@@ -1,4 +1,4 @@
-#KubOS Linux on the ISIS iOBC
+# KubOS Linux on the ISIS iOBC
 
 [Overview](#overview)
 

--- a/docs/kubos-linux-on-iobc.md
+++ b/docs/kubos-linux-on-iobc.md
@@ -11,6 +11,10 @@
 The goal of this document is to create a KubOS Linux installation for the iOBC that can then run the satellite services (telemetry, payload communication, etc) 
 needed for the ISIS customers' missions.
 
+The [User Applications on the ISIS iOBC](docs/user-app-on-iobc.md) doc can then be used to create and load a user application on top of the new KubOS Linux install.
+
+**Note:** Ideally, the user should never have to mess with the kernel themselves.  It should be pre-loaded onto the iOBC.
+
 ##Software Components
 
 ###ISIS Bootloader

--- a/docs/kubos-linux-overview.md
+++ b/docs/kubos-linux-overview.md
@@ -6,8 +6,8 @@ This is intended as a higher-level overview of the KubOS Linux configuration, in
 
 The high level components of every system will be:
 - Low-level bootloader/s
-- U-Boot (mid-level bootloader. Loads linux)
-- Linux
+- U-Boot (mid-level bootloader. Loads KubOS Linux)
+- KubOS Linux
 
 Ideally, all the files will be delivered to the customer as a pre-baked OBC. They'll just need to upload their user app files onto the board.
 
@@ -45,7 +45,7 @@ basic OS and CLI which can be used to configure and debug the kernel before it's
 
 Final distribution: uboot.bin
 
-### Linux Kernel
+### KubOS Linux Kernel
 
 The kernel can be built to support many boards at a time.  It is usually only constrained by high-level hardware things like CPU architecture (ex. ARM).
 Some systems may need non-standard kernel because of size or other constraints.

--- a/docs/kubos-linux-overview.md
+++ b/docs/kubos-linux-overview.md
@@ -88,19 +88,19 @@ added, they will likely be added through the busybox configuration.
 
 Currently enabled BusyBox commands:
 
-    [, [[, addgroup, adduser, cat, catv, chgrp, chmod, chown, chpasswd,
-    chroot, cksum, clear, cp, cut, date, deallocvt, delgroup, deluser, df,
-    dirname, du, dumpkmap, echo, egrep, env, expr, false, fgrep, find,
-    fold, fsync, getty, grep, gzip, halt, hush, id, init, inotifyd, ionice,
-    iostat, kill, killall, killall5, linuxrc, ln, loadkmap, login, logname,
-    ls, lzcat, lzma, man, mkdir, mknod, mkpasswd, modinfo, more, mount, mv,
-    nice, passwd, pkill, poweroff, printenv, printf, ps, pwd, readlink,
-    realpath, reboot, renice, reset, resize, rm, rmdir, sed, seq,
-    setserial, sh, sha256sum, sha512sum, sleep, sort, split,
-    start-stop-daemon, stat, stty, sync, tail, tar, tee, test, time,
-    timeout, top, touch, tr, true, truncate, umount, uname, uncompress,
-    unlink, unlzma, unshare, unzip, uptime, usleep, vi, watch, watchdog,
-    wc, which, whoami, yes
+        [, [[, acpid, adjtimex, ar, arp, arping, ash, awk, basename, blockdev, brctl, bunzip2, bzcat, bzip2, cal, cat, chgrp, chmod, chown, chpasswd,
+        chroot, chvt, clear, cmp, cp, cpio, crond, crontab, cttyhack, cut, date, dc, dd, deallocvt, depmod, devmem, df, diff, dirname, dmesg,
+        dnsdomainname, dos2unix, dpkg, dpkg-deb, du, dumpkmap, dumpleases, echo, ed, egrep, env, expand, expr, false, fdisk, fgrep, find, fold, free,
+        freeramdisk, fstrim, ftpget, ftpput, getopt, getty, grep, groups, gunzip, gzip, halt, head, hexdump, hostid, hostname, httpd, hwclock, id,
+        ifconfig, ifdown, ifup, init, insmod, ionice, ip, ipcalc, kill, killall, klogd, last, less, ln, loadfont, loadkmap, logger, login, logname,
+        logread, losetup, ls, lsmod, lzcat, lzma, lzop, lzopcat, md5sum, mdev, microcom, mkdir, mkfifo, mknod, mkswap, mktemp, modinfo, modprobe, more,
+        mount, mt, mv, nameif, nc, netstat, nslookup, od, openvt, passwd, patch, pidof, ping, ping6, pivot_root, poweroff, printf, ps, pwd, rdate,
+        readlink, realpath, reboot, renice, reset, rev, rm, rmdir, rmmod, route, rpm, rpm2cpio, run-parts, sed, seq, setkeycodes, setsid, sh, sha1sum,
+        sha256sum, sha512sum, sleep, sort, start-stop-daemon, stat, static-sh, strings, stty, su, sulogin, swapoff, swapon, switch_root, sync, sysctl,
+        syslogd, tac, tail, tar, taskset, tee, telnet, telnetd, test, tftp, time, timeout, top, touch, tr, traceroute, traceroute6, true, tty, tunctl,
+        udhcpc, udhcpd, umount, uname, uncompress, unexpand, uniq, unix2dos, unlzma, unlzop, unxz, unzip, uptime, usleep, uudecode, uuencode, vconfig,
+        vi, watch, watchdog, wc, wget, which, who, whoami, xargs, xz, xzcat, yes, zcat
+
 
 
 ### Device Tree Binary

--- a/docs/kubos-linux-overview.md
+++ b/docs/kubos-linux-overview.md
@@ -1,4 +1,4 @@
-#KubOS Linux Overview
+# KubOS Linux Overview
 
 ##Introduction
 

--- a/docs/kubos-standards.md
+++ b/docs/kubos-standards.md
@@ -1,4 +1,4 @@
-#Kubos Standards
+# Kubos Standards
 
 This is a doc to maintain the current naming and coding standards when working with the Kubos project.
 

--- a/docs/kubos-standards.md
+++ b/docs/kubos-standards.md
@@ -1,0 +1,55 @@
+#Kubos Standards
+
+This is a doc to maintain the current naming and coding standards when working with the Kubos project.
+
+##Product Names
+
+The general naming scheme is "Kub[OS|os] {component}".  Note that there is a space separating the two words.
+
+If the component is an OS, then use the capitalized "OS".  If not, then use "os".
+
+The component should be capitalized like a normal proper noun.  First letter capitalized if the component is
+a word, all letters capitalized if the component is an initialism.
+
+- Kubos SDK
+- Kubos CLI
+- KubOS RT
+- KubOS Linux
+- Kubos Portal
+- Kubos Core
+
+##File Naming
+
+###Code (\*.c, \*.h, scripts, etc)
+
+- No spaces
+- Use underscores to separate words
+- All lowercase
+
+###Docs (\*.md)
+
+- No spaces
+- Use hyphens to separate words
+- All lowercase
+
+###Folders
+
+- No spaces
+- Use hyphens to separate words
+- All lowercase
+
+###Special Files
+
+The contributing, license, and readme files should all be uppercased.
+
+'Vagrantfile', 'Makefile', 'CMake', and other similar files should all be cased to match industry standards.
+
+##Coding Standards
+
+This section should be updated as coding standards are decided.
+
+###C
+
+- Four spaces, not tabs (for consistency between OS's)
+- All brackets should be on their own line
+- All `if` statements should use brackets

--- a/docs/main.md
+++ b/docs/main.md
@@ -12,9 +12,9 @@ Looking to build an application on Kubos? Check out our [quick start guide](docs
  
 ### Kubos SDK
 
- - [Installing Kubos SDK](docs/cli-installing.md)
+ - [Installing Kubos SDK](docs/sdk-installing.md)
 
- - [Upgrading Kubos SDK](docs/cli-upgrading.md)
+ - [Upgrading Kubos SDK](docs/sdk-upgrading.md)
 
  - [Creating your first project](docs/first-project.md)
 
@@ -31,9 +31,9 @@ Looking to build an application on Kubos? Check out our [quick start guide](docs
  
 ### KubOS Linux
  
- - [KubOS Linux Overview](docs/linux-overview.md)
+ - [KubOS Linux Overview](docs/kubos-linux-overview.md)
  
- - [KubOS Linux on iOBC](docs/linux-on-iobc.md)
+ - [KubOS Linux on iOBC](docs/kubos-linux-on-iobc.md)
  
  - [User Applications on iOBC](docs/user-app-on-iobc.md)
 
@@ -48,4 +48,8 @@ Looking to build an application on Kubos? Check out our [quick start guide](docs
 
  - [CSP](./libcsp/index.html)
  
- - [Telemetry](./telemetry.html)
+ - [Telemetry](./telemetry/index.html)
+ 
+ - [Telemetry Aggregator](./telemetry-aggregator/index.html)
+ 
+ - [IPC](./ipc/index.html)

--- a/docs/main.md
+++ b/docs/main.md
@@ -1,49 +1,51 @@
-### KubOS
+### Kubos
 
-The KubOS platform provides small satellite developers the tools and libraries necessary to quickly bring up space ready software. We leverage multiple existing open source projects like FreeRTOS and CSP, along with our own custom framework and SDK.
+The Kubos platform provides small satellite developers the tools and libraries necessary to quickly bring up space ready software. We leverage multiple existing open source projects like FreeRTOS and CSP, along with our own custom framework and SDK.
 
-Looking to build an application on KubOS? Check out our [quick start guide](docs/first-project.md).
+Looking to build an application on Kubos? Check out our [quick start guide](docs/first-project.md).
 
 ## Docs
 
  - [Changelog](docs/changelog.md)
- - [Contributing to the KubOS Project](docs/contribution-process.md)
+ - [Contributing to the Kubos Project](docs/contribution-process.md)
  - [Kubos Naming and Coding Standards](docs/kubos-standards.md)
  
-### KubOS SDK
+### Kubos SDK
 
- - [Installing Kubos-CLI](docs/cli-installing.md)
+ - [Installing Kubos SDK](docs/cli-installing.md)
 
- - [Upgrading Kubos-CLI](docs/cli-upgrading.md)
+ - [Upgrading Kubos SDK](docs/cli-upgrading.md)
 
  - [Creating your first project](docs/first-project.md)
 
- - [KubOS-SDK Command Reference](docs/sdk-reference.md)
+ - [Kubos SDK Command Reference](docs/sdk-reference.md)
 
- - [KubOS Module Development](docs/kubos-development.md)
+ - [Kubos Module Development](docs/kubos-development.md)
 
  
 ### KubOS RT
 
- - [MSP430 Launchpad Guide](docs/MSP430-launchpad-guide.md)
+ - [MSP430 Launchpad Guide](docs/msp430-launchpad-guide.md)
 
- - [STM32F4 Discovery Board Guide](docs/STM32F4-discovery-board-guide.md)
+ - [STM32F4 Discovery Board Guide](docs/stm32f4-discovery-board-guide.md)
  
 ### KubOS Linux
  
- - [KubOS Linux Overview](docs/Linux_Overview.md)
+ - [KubOS Linux Overview](docs/linux-overview.md)
  
- - [KubOS Linux on iOBC](docs/Linux_on_iOBC.md)
+ - [KubOS Linux on iOBC](docs/linux-on-iobc.md)
  
- - [User Applications on iOBC](docs/User_App_on_iOBC.md)
+ - [User Applications on iOBC](docs/user-app-on-iobc.md)
 
 
 ## Top Level APIs
 
- - [KubOS HAL](./kubos-hal/index.html)
+ - [Kubos HAL](./kubos-hal/index.html)
 
- - [KubOS Core](./kubos-core/index.html)
+ - [Kubos Core](./kubos-core/index.html)
 
  - [FreeRTOS](./freertos/index.html)
 
  - [CSP](./libcsp/index.html)
+ 
+ - [Telemetry](./telemetry.html)

--- a/docs/main.md
+++ b/docs/main.md
@@ -4,6 +4,10 @@ The Kubos platform provides small satellite developers the tools and libraries n
 
 Looking to build an application on Kubos? Check out our [quick start guide](docs/first-project.md).
 
+Having issues? Want a new feature? [Come talk to us!](https://slack.kubos.co/)
+
+If for some reason Slack won't work for you, feel free to email us at info@kubos.co.
+
 ## Docs
 
  - [Changelog](docs/changelog.md)

--- a/docs/main.md
+++ b/docs/main.md
@@ -18,7 +18,7 @@ Looking to build an application on Kubos? Check out our [quick start guide](docs
 
  - [Creating your first project](docs/first-project.md)
 
- - [Kubos SDK Command Reference](docs/sdk-reference.md)
+ - [Kubos CLI Command Reference](docs/sdk-reference.md)
 
  - [Kubos Module Development](docs/kubos-development.md)
 

--- a/docs/main.md
+++ b/docs/main.md
@@ -7,6 +7,8 @@ Looking to build an application on KubOS? Check out our [quick start guide](docs
 ## Docs
 
  - [Changelog](docs/changelog.md)
+ - [Contributing to the KubOS Project](docs/contribution-process.md)
+ - [Kubos Naming and Coding Standards](docs/kubos-standards.md)
  
 ### KubOS SDK
 
@@ -20,7 +22,6 @@ Looking to build an application on KubOS? Check out our [quick start guide](docs
 
  - [KubOS Module Development](docs/kubos-development.md)
 
- - [Contributing to the KubOS Project](docs/contribution-process.md)
  
 ### KubOS RT
 

--- a/docs/msp430-launchpad-guide.md
+++ b/docs/msp430-launchpad-guide.md
@@ -1,4 +1,4 @@
-#MSP430 Discovery Board Guide
+# MSP430 Discovery Board Guide
 
 - [Reference Documents](#reference-documents)
 - [Pin Definitions](#pin-definitions)

--- a/docs/msp430-launchpad-guide.md
+++ b/docs/msp430-launchpad-guide.md
@@ -20,14 +20,14 @@
 
 -	[MSP430F5529 Header File](http://ece.wpi.edu/courses/ece2049smj/msp430f5529.h)  Contains many of the pin and register constants
 
-**KubOS Documentation:**
+**Kubos Documentation:**
 
-- [Main HAL API documentation](http://docs.kubos.co/latest/kubos-hal/index.html) - Overview of the high-level HAL.  Useful for things like k\_uart\_write.
-- [MSP430F5 Specific HAL API documentation](http://docs.kubos.co/latest/kubos-hal/kubos-hal-msp430f5529/) - Specifics for the MSP430 version of the HAL.
+- [Main HAL API documentation](./kubos-hal/index.html) - Overview of the high-level HAL.  Useful for things like k\_uart\_write.
+- [MSP430F5 Specific HAL API documentation](./kubos-hal/kubos-hal-msp430f5529/index.html) - Specifics for the MSP430 version of the HAL.
 Useful for things like the configuration options.
-- [Installing the Kubos SDK](http://docs.kubos.co/latest/md_docs_cli-installing.html) - Basics of setting up the Kubos SDK environment
-- [Creating your first project](http://docs.kubos.co/latest/md_docs_first-project.html) - Steps to create and build a Kubos SDK project
-- [SDK Command Reference](http://docs.kubos.co/latest/md_docs_cli-reference.html) - Overview of the common Kubos SDK commands
+- [Installing the Kubos SDK](docs/cli-installing.md) - Basics of setting up the Kubos SDK environment
+- [Creating your first project](docs/first-project.md) - Steps to create and build a Kubos SDK project
+- [SDK Command Reference](docs/sdk-reference.md) - Overview of the common Kubos SDK commands
 
 ## Pin Definitions
 
@@ -81,15 +81,15 @@ Your main() should look something like this:
 ## Configuration Notes
 
 The MSP430's inter-device communication methods do not support all of the same options as the STM32F4.  For example, the MSP430 does not support
-1-wire half-duplex SPI communication.  Please refer to the User's Guide or the [MSP430's HAL Documentation](http://docs.kubos.co/latest/kubos-hal/kubos-hal-msp430f5529/index.html) for all of the supported options.
+1-wire half-duplex SPI communication.  Please refer to the User's Guide or the [MSP430's HAL Documentation](./kubos-hal/kubos-hal-msp430f5529/index.html) for all of the supported options.
 
-[UART](http://docs.kubos.co/latest/kubos-hal/structKUARTConf.html)
+[UART](./kubos-hal/structKUARTConf.html)
 - Word length - Does not support 9-bit mode
 
-[I2C](http://docs.kubos.co/latest/kubos-hal/structKI2CConf.html)
+[I2C](./kubos-hal/structKI2CConf.html)
 - Currently has all the same capabilities as the STM32F4
 
-[SPI](http://docs.kubos.co/latest/kubos-hal/structKSPIConf.html)
+[SPI](./kubos-hal/structKSPIConf.html)
 - Direction - Does not support 1-line mode
 - Data Size - Does not support 16-bit mode
 
@@ -98,14 +98,11 @@ The MSP430's inter-device communication methods do not support all of the same o
 You'll flash the firmware onto your board through the micro-USB port.  You might need to install drivers in order for the board
 to be properly detected by your computer.  If you're using Windows, the drivers can be found [here](http://software-dl.ti.com/msp430/msp430_public_sw/mcu/msp430/MSP430_FET_Drivers/latest/index_FDS.html).
 
-If you're using a VM, you'll need to pass the USB through to the VM in order to flash.  The board should appear as the 
-"Texas Instruments MSP Tools Driver" device.  Do not set up auto-forwarding for the USB port if you want to open the debug console locally.
-If you want to open the debug console on your VM, then auto-forwarding should be fine.
-
+If you have a Kubos vagrant image running, the USB connection should be automatically passed through to the VM.  The board should appear as the 
+"Texas Instruments" device if you issue the `lsusb` command.
 Run 'kubos flash' in order to start the flash process.
 
-If you see a "*No unused FET found*" message, the board either isn't plugged into your computer or you haven't passed the USB 
-through to your VM.
+If you see a "*No unused FET found*" message, the board either isn't plugged into your computer or some other VM has control of the USB (only one VM can have control of the USB at a time).
 
 If you see any other error messages, like "*device initialization failed*" re-run the flash command.
 
@@ -357,7 +354,7 @@ Build the program
 	
 Flash the program
 
-	$ sudo kubos flash
+	$ kubos flash
 	
 Connect to the debug console.  Should see an "echo, x=_n_" message every second.  If you press the P2.1 button, you should see
 "Button_0 pressed".

--- a/docs/stm32f4-discovery-board-guide.md
+++ b/docs/stm32f4-discovery-board-guide.md
@@ -1,4 +1,4 @@
-#STM32F4 Discovery Board Guide
+# STM32F4 Discovery Board Guide
 
 - [Reference Documents](#reference-documents)
 - [Pin Definitions](#pin-definitions)

--- a/docs/stm32f4-discovery-board-guide.md
+++ b/docs/stm32f4-discovery-board-guide.md
@@ -15,14 +15,14 @@ These are the two most useful documents to have while working with the STM32F4
 
 -	[STM32F4 Discovery Board User Manual](http://www.st.com/content/ccc/resource/technical/document/user_manual/70/fe/4a/3f/e7/e1/4f/7d/DM00039084.pdf/files/DM00039084.pdf/jcr:content/translations/en.DM00039084.pdf) Useful for the pin layouts.
 
-**KubOS Documentation:**
+**Kubos Documentation:**
 
-- [Main HAL API documentation](http://docs.kubos.co/latest/kubos-hal/index.html) - Overview of the high-level HAL.  Useful for things like k\_uart\_write.
-- [STM32F4 Specific HAL API documentation](http://docs.kubos.co/latest/kubos-hal/kubos-hal-stm32f4/index.html) - Specifics for the STM32F4 version of the HAL.
+- [Main HAL API documentation](./kubos-hal/index.html) - Overview of the high-level HAL.  Useful for things like k\_uart\_write.
+- [STM32F4 Specific HAL API documentation](./kubos-hal/kubos-hal-stm32f4/index.html) - Specifics for the STM32F4 version of the HAL.
 Useful for things like the configuration options.
-- [Installing the Kubos SDK](http://docs.kubos.co/latest/md_docs_cli-installing.html) - Basics of setting up the Kubos SDK environment
-- [Creating your first project](http://docs.kubos.co/latest/md_docs_first-project.html) - Steps to create and build a Kubos SDK project
-- [SDK Command Reference](http://docs.kubos.co/latest/md_docs_cli-reference.html) - Overview of the common Kubos SDK commands
+- [Installing the Kubos SDK](docs/cli-installing.md) - Basics of setting up the Kubos SDK environment
+- [Creating your first project](docs/first-project.md) - Steps to create and build a Kubos SDK project
+- [SDK Command Reference](docs/sdk-reference.md) - Overview of the common Kubos SDK commands
 
 ## Pin Definitions
 
@@ -46,7 +46,7 @@ Look at section 6.11 (Extension connectors)
 
 Look at:
 
-	KubOS/targets/target-stm32f407-disco-gcc/target.json
+	kubos/targets/target-stm32f407-disco-gcc/target.json
 	
 Look for the i2c, spi, or uart section to find the pin definitions
 	
@@ -190,7 +190,7 @@ Create the program in main.c:
 ~~~~c
 /*
  * KubOS RT
- * Copyright (C) 2016 Kubos Corporation
+ * Copyright (C) 2017 Kubos Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -300,6 +300,6 @@ Build the program
 	
 Flash the program
 
-	$ sudo kubos flash
+	$ kubos flash
 	
 Connect to the debug console (UART6).  Should see a "Received: ping" message every second.

--- a/docs/user-app-on-iobc.md
+++ b/docs/user-app-on-iobc.md
@@ -1,4 +1,4 @@
-#User Applications on the ISIS iOBC
+# User Applications on the ISIS iOBC
 
 - [Reference Documents](#reference-documents)
 - [Building a Project](#building-a-project)
@@ -12,12 +12,12 @@
 
 ## Reference Documents
 
-###iOBC Documentation
+### iOBC Documentation
 
 The ISIS-OBC Quickstart Guide should have been packaged with the iOBC and is a useful document for learning what each of the hardware components are, how to 
 connect them, and what drivers need to be installed to support them.
 
-###Kubos Documentation
+### Kubos Documentation
 
 - [Installing the Kubos SDK](docs/cli-installing.md) - Basics of setting up the Kubos SDK environment
 - [Creating your first project](docs/first-project.md) - Steps to create and build a Kubos SDK project (Note: Written for a KubOS RT end-target)
@@ -25,7 +25,7 @@ connect them, and what drivers need to be installed to support them.
 - [KubOS Linux Overview](docs/kubos-linux-Overview.md) - Overview of the KubOS Linux components
 - [KubOS Linux on iOBC](docs/kubos-linux-on-iobc.md) - Steps to build and load KubOS Linux for the iOBC
 
-##Building a Project
+## Building a Project
 
 In order to build a project for the ISIS-OBC, you'll need to create a Kubos SDK project for KubOS Linux, set the correct target, and then build it.
 
@@ -33,7 +33,7 @@ In order to build a project for the ISIS-OBC, you'll need to create a Kubos SDK 
     $ kubos target kubos-linux-isis-gcc
     $ kubos build
     
-##Updating Credentials
+## Updating Credentials
 
 Ideally, you should not be using the default root user password.  If you've changed it, you'll need to pass the new password to the Kubos flash utility
 through the config.json file, which should be located in the top-level directory of your project.  You'll need to create the file if it doesn't already
@@ -47,7 +47,7 @@ If you're creating a brand new config.json file, you can just copy and paste the
         }
     }
     
-##Updating the USB Connection
+## Updating the USB Connection
 
 The iOBC should be shipped with an FTDI cable.  This cable should be connected to the programming adapter, which should then be connected to the iOBC, to create the
 debug UART connection.  User file transfer will take place using this connection.
@@ -57,7 +57,7 @@ need to pass through the USB connection, and then update the minicom configurati
 
 You can either pass through the USB via VirtualBox or by updating the vagrant's Vagrantfile.
 
-###VirtualBox
+### VirtualBox
 
 Open the VirtualBox Manager
 
@@ -71,7 +71,7 @@ Click the USB icon with the plus symbol to add a new USB filter.  Select the dev
 
 ![VM USB Devices](images/usb_devices.png)
 
-###Updating the Vagrantfile
+### Updating the Vagrantfile
 
 Navigate to you vagrant installation directory on your host machine.
 
@@ -88,7 +88,7 @@ The description can be whatever you want, but the vendor and product IDs will ne
 Once you've updated Vagrantfile, issue the command `vagrant reload` to cause the VM to pick up the new definition.  Once you've logged in to the VM, you 
 should be able to see the passed-through connection with the `lsusb` command.
 
-####On Windows
+#### On Windows
 
 1. Go to the "Start" Menu.
 2. Select "Devices and Printers"
@@ -99,13 +99,13 @@ should be able to see the passed-through connection with the `lsusb` command.
 7. From the "Device description" Menu select "Hardware Ids"
 8. Copy the numbers next to "VID_" and "PID_"
 
-####On Mac
+#### On Mac
 
 Issue the `system_profiler SPUSBDataType` command.  
 
 Copy the values in the values in the 'Product ID' and 'Vendor ID' fields
 
-####On Linux
+#### On Linux
 
 Issue the `lsusb` command.
 
@@ -121,7 +121,7 @@ Edit the file and update the 'pu baudrate' field and change '/dev/FTDI' to the '
 
 You can test the changes by issuing the `minicom kubos` command.  If you successfully connect to your board, then the changes have been successful.
 
-##Flashing the Board
+## Flashing the Board
 
 The USB-to-serial cable should be connected to the iOBC and the board should be fully powered.
 
@@ -134,7 +134,7 @@ Assuming you've successfully built a Kubos SDK project for the ISIS-OBC board, w
     Transfer Successful
     Execution time: 21 seconds
 
-##Troubleshooting
+## Troubleshooting
 
 "No compatible FTDI device found"
 
@@ -164,7 +164,7 @@ System appears to have hung
 - If you've waited a couple minutes and the system still appears hung, please let us know so that we can open a bug report.
 
 
-##Debug Console
+## Debug Console
 
 If the iOBC is correctly connected to your host computer, you should see a /dev/ttyUSB* device in your vagrant VM.  The VM is set up to automatically forward any
 FTDI cables that connect to a /dev/FTDI device for ease-of-use.
@@ -194,7 +194,7 @@ Fully logged in, the console should look like this:
     Jan  1 00:00:16 login[212]: root login on 'ttyS0'
     ~ # 
 
-##Manual File Transfer
+## Manual File Transfer
 
 If for some reason you want to manual transfer a specific file onto the iOBC, for example a custom script, you'll need to do the following:
 

--- a/docs/user-app-on-iobc.md
+++ b/docs/user-app-on-iobc.md
@@ -17,13 +17,13 @@
 The ISIS-OBC Quickstart Guide should have been packaged with the iOBC and is a useful document for learning what each of the hardware components are, how to 
 connect them, and what drivers need to be installed to support them.
 
-###KubOS Documentation
+###Kubos Documentation
 
 - [Installing the Kubos SDK](docs/cli-installing.md) - Basics of setting up the Kubos SDK environment
 - [Creating your first project](docs/first-project.md) - Steps to create and build a Kubos SDK project (Note: Written for a KubOS RT end-target)
 - [SDK Command Reference](docs/cli-reference.md) - Overview of the common Kubos SDK commands
-- [KubOS Linux Overview](docs/Linux_Overview.md) - Overview of the KubOS Linux components
-- [KubOS Linux on iOBC](docs/Linux_on_iOBC.md) - Steps to build and load KubOS Linux for the iOBC
+- [KubOS Linux Overview](docs/kubos-linux-Overview.md) - Overview of the KubOS Linux components
+- [KubOS Linux on iOBC](docs/kubos-linux-on-iobc.md) - Steps to build and load KubOS Linux for the iOBC
 
 ##Building a Project
 
@@ -259,6 +259,7 @@ Select the file to send
 * Press `g` to open the Goto dialog and navigate to the desired folder (full pathname required)
 * Press enter to open the file selector dialog and specify the file you want within the current folder
 
+
     +-------------------[Select one or more files for upload]-------------------+
     |Directory: /home/vagrant/linux/build/kubos-linux-isis-gcc/source           |
     | [..]                                                                      |
@@ -354,3 +355,5 @@ Output should look like this:
     Packet received on MY_PORT: Hello World
     
 Press **Ctrl+C** to exit execution.
+
+Press **Ctrl+A**, then **Q** to exit minicom.

--- a/docs/user-app-on-iobc.md
+++ b/docs/user-app-on-iobc.md
@@ -255,10 +255,11 @@ Select zmodem
     
                    [Goto]  [Prev]  [Show]   [Tag]  [Untag] [Okay]
 
-Select the file to send
-* Press `g` to open the Goto dialog and navigate to the desired folder (full pathname required)
-* Press enter to open the file selector dialog and specify the file you want within the current folder
+Select the file to send:
 
+Press `g` to open the Goto dialog and navigate to the desired folder (full pathname required).
+
+Press enter to open the file selector dialog and specify the file you want within the current folder.
 
     +-------------------[Select one or more files for upload]-------------------+
     |Directory: /home/vagrant/linux/build/kubos-linux-isis-gcc/source           |


### PR DESCRIPTION
Making doc changes per Issue #39 

<details><summary>Checklist</summary>
  <p>

- [ ] kubos
	- [ ] changelog
		- [ ] Update it :P
	- [x] main.md
		- [x] Update all product names to be consistent
			- [x] Kubos SDK
			- [x] Kubos CLI
			- [x] KubOS Linux
			- [x] KubOS RT
		- [x] Update file names to be consistent
			- [x] hypens, not underscores
			- [x] constistent casing
		- [x] Move 'contributing' to by changelog (not a sub-document)
		- [x] Add API link for telemetry
		- [x] should telemetry-aggregator and ipc also be exposed?
		- [x] "Installing CLI" - misleading.  it's also installing vagrant.  Should probably still be "Installing SDK"
		- [x] "Upgrading CLI" -> Upgrading SDK or Upgrading SDK components
    - [x] Create standards doc
	- [x] contribution-process
		- [x] Update 'create a jira issue'
			for stories: follow standard 'as a [user]' format
			mention linking to epics
		- [x] Change 'create personal copy'
			we're making branches against master now
		- [x] create a pull request
			verify instructions still accurate
			mention tagging people for review
			mention WIP tag
		- [x] add 'JIRA -> Reviewing' blurb for stories waiting for PR approval
	- [ ] cli-installing - Misnomer.  Really, installing sdk
		- [ ] Fix 'kubos-sdk'
		- [ ] update vagrant box name
		- [ ] Typo: "current Directory"
		- [ ] "It is strongly recommended" - need handholding for this
		- [ ] Mounting synced folders - update instructions.  No example line currently exists
		- [ ] Missing 'vagrant up' line
		- [ ] A link to the upgrading doc might be nice
	- [ ] cli-upgrading
		- [ ] Kubos -> KubOS
		- [ ] Fix naming (kubos-cli -> KubOS CLI)
		- [ ] Add 'to check which version of cli, use `kubos version`'
		- [ ] Typo: "avaialble"
		- [ ] sudo kubos update -> kubos update
		- [ ] add blurb about `kubos use`
		- [ ] Add section about downgrading each component (or stick in a different doc)
		- [ ] A link to the install doc might be nice
	- [x] first-project
		- [x] fix naming
		- [x] update vagrant box name
		- [x] Repeat of shared folder note: handholding.  Alternatively, remove this section, since it's not really related to building your first test project.
			- [x] also, is this still the recommended practice?  How do you do `kubos init` on the host machine?  b/c you can't do `kubos init` on a folder that already exists...
		- [x] Add link for example linux project
	- [ ] cli-reference
		- [ ] Add links at the top to each section
		- [ ] An overview section with all of the kubos commands and the quick description at the top could be nice.  basically just copy paste the output of `kubos --help`, or make a pretty table.
		- [ ] Possibly re-org.  Most command references are ordered by command, not by function.
			- [ ] If not re-org, then the doc should be renamed.  SDK Process Overview, or something...
		- [ ] go into way more detail on all the things.
		- [ ] Make sure all kubos commands and all their options are documented here.
		- [ ] "Yotta needs" -> "KubOS CLI needs"
		- [ ] "kubos build -- -v" - what's the '--' for?
		*** Kubos linking description/instructions could probable use some going over.
		- [ ] is there a script for linking everything now?
		- [ ] 'TODO' do the thing.
	*** A troubleshooting/FAQ doc could be good.
	- [x] kubos-development.md
		- [x] Fix naming
		- [x] Expand intro blurb with overview of development process.  "If you want to make changes to the Kubos code, perhaps for debugging purposes, you'll need to clone the kubos repo and then link the changed modules to your kubos sdk project" - or something to that effect.
		- [x] Getting started - "Modifying an existing Kubos module" doesn't make sense for the text that follows
		- [x] Since it's recommended to use external shared folders, it might be good to give the process for cloning kubos externally
		and then linking it in the Vagrantfile and running 'vagrant reload''
		- [x] 'Yotta' - Make hyperlink to yotta docs
		- [x] Linking in a local module - make example directory an actual directory.
			- [x] "Let's say you want to add debug lines to {module}..." - Use actual module path.
		- [x] Change /home/kubos/example to /home/kubos/<project_name> to match previous example `kubos init`
		- [x] Add instructions for how to unlink modules?
	- [x] MSP430-launchpad-guide
		- [x] Fix naming
		- [x] Update kubos doc links to match formatting of other docs.  "docs/[doc]"
		- [x] Flashing the board - update the USB passthrough description.  Vagrant should be doing it now.
		- [x] "sudo kubos flash" - is the sudo still required?
	- [x] STM32F4-discovery-board-guide
		- [x] Fix naming
		- [x] Fix doc URLs for consistency
		- [x] Fix "sudo kubos flash"?
	- [x] Linux_Overview
		- [x] change file name. underscores->hyphen.  Add 'kubos'
		- [x] Linux -> KubOS Linux
		- [x] Update busybox commands list
	- [x] Linux_on_iobc
		- [x] change file name. underscores->hyphen.  Add 'kubos'
		- [x] Better highlight that this is a doc specifically for the bootloaders and kernel, not user applications.  Should only be needed if the kernel is not pre-loaded onto the board, or if the kernel needs to be manually updated for some reason.
	- [x]  User_App_on_iOBC
		- [x] change file name.
		- [x] change "KubOS Documentation" -> "Kubos Documentation", since the SDK is lower case, we're just referring to the company's documentation.
		- [x] Fix zModem file selector example formatting
		- [x] Example - Add command to exit minicom at very end

</p></details>