### PR TITLE
[KUBOS-313] KubOS Linux Non-application File Transfer

### DIFF
--- a/docs/sdk-reference.md
+++ b/docs/sdk-reference.md
@@ -14,6 +14,10 @@ The `kubos` command is always run with a subcommand in order to do something, `k
 
 [debug](#kubos-debug)               Attach a debugger to the current target.  Requires target support.
 
+[flash](#kubos-flash)               Launch the compiled program (available for executable modules only). Requires target support for cross-compiling targets.
+
+[flash](#kubos-flash-linux) (KubOS Linux) Load files onto target.
+
 [init](#kubos-init)                Create a new module.
 
 [licenses](#kubos-licenses)            List the licenses of the current module and its dependencies.
@@ -23,8 +27,6 @@ The `kubos` command is always run with a subcommand in order to do something, `k
 [link-target](#kubos-link-target)         Symlink a target
 
 [list](#kubos-list)                List the dependencies of the current module, or the inherited targets of the current target.
-
-[flash](#kubos-flash)               Launch the compiled program (available for executable modules only). Requires target support for cross-compiling targets.
 
 [target](#kubos-target)              Set or display the target device.
 
@@ -180,6 +182,28 @@ Flash the build of the current target to the target board.
 
 Note: This requires target support.
 
+## kubos flash (KubOS Linux) {#kubos-flash-linux}
+Synonyms: `kubos start`
+
+### Synopsis
+
+        $ kubos flash [file]
+
+### Description
+Flash a file to the target board.
+
+If the name of the file matches the name of the application, as specified in the module.json file, then the file is assumed to be the application binary and
+will be loaded into /home/usr/bin on the target board.
+
+If the name of the file ends in *.itb, the file is a KubOS Linux upgrade package and will be loaded into the upgrade partition of the target board. An internal
+variable will be set so that the upgrade package will be installed during the next reboot of the target board.
+
+All other files are assumed to be non-application files (ex. custom shell scripts) and will be loaded into /home/usr/local/bin.
+
+### Arguments
+* `file` File to flash.
+
+Note: This requires target support.
 
 ## kubos update {#kubos-update}
 

--- a/targets/target-kubos-linux-isis-gcc/minicom/flash.sh
+++ b/targets/target-kubos-linux-isis-gcc/minicom/flash.sh
@@ -26,6 +26,8 @@ spinner() {
 start=$(date +%s)
 
 this_dir=$(cd "`dirname "$0"`"; pwd)
+project=$(cd "../.."; pwd)
+project=$(basename $project)
 program=$1
 name=$(basename $1)
 is_upgrade=0
@@ -55,6 +57,8 @@ fi
 if [[ "$name" = *.itb ]]; then
     path="/upgrade"
     is_upgrade=1
+else if [[ "$name" != "$project" ]]; then
+    path="/home/usr/local/bin"
 else
     path="/home/usr/bin"
 fi

--- a/targets/target-kubos-linux-isis-gcc/minicom/flash.sh
+++ b/targets/target-kubos-linux-isis-gcc/minicom/flash.sh
@@ -16,7 +16,7 @@
 
 progress() {
     while sleep 1; do
-        line=$(tac flash.log | grep -m 1 "Bytes Sent")
+        line=$(cat flash.log | grep "Bytes Sent")
         printf "$line\r"
     done   
 }

--- a/targets/target-kubos-linux-isis-gcc/minicom/flash.sh
+++ b/targets/target-kubos-linux-isis-gcc/minicom/flash.sh
@@ -33,6 +33,7 @@ name=$(basename $1)
 is_upgrade=0
 
 password=$(cat yotta_config.json | python -c 'import sys,json; x=json.load(sys.stdin); print x["system"]["password"]')
+dest_dir=$(cat yotta_config.json | python -c 'import sys,json; x=json.load(sys.stdin); print x["system"]["destDir"]')
 
 unamestr=`uname`
 
@@ -58,7 +59,7 @@ if [[ "$name" = *.itb ]]; then
     path="/upgrade"
     is_upgrade=1
 else if [[ "$name" != "$project" ]]; then
-    path="/home/usr/local/bin"
+    path="$destDir"
 else
     path="/home/usr/bin"
 fi
@@ -77,6 +78,7 @@ expect {
     "~ #" break
     timeout 5 goto end
 }
+send "mkdir $path"
 send "cd $path"
 send "rm $name"
 send "rz -bZ"

--- a/targets/target-kubos-linux-isis-gcc/minicom/flash.sh
+++ b/targets/target-kubos-linux-isis-gcc/minicom/flash.sh
@@ -14,26 +14,22 @@
 # limitations under the License.
 #
 
-spinner() {
-    local sp i n
-    sp='/-\|'
-    n=${#sp}
-    while sleep 0.15; do
-        printf "%s\b" "${sp:i++%n:1}"
-    done
+progress() {
+    while sleep 1; do
+        line=$(tac flash.log | grep -m 1 "Bytes Sent")
+        printf "$line\r"
+    done   
 }
 
 start=$(date +%s)
 
 this_dir=$(cd "`dirname "$0"`"; pwd)
-project=$(cd "../.."; pwd)
-project=$(basename $project)
-program=$1
 name=$(basename $1)
 is_upgrade=0
 
 password=$(cat yotta_config.json | python -c 'import sys,json; x=json.load(sys.stdin); print x["system"]["password"]')
 dest_dir=$(cat yotta_config.json | python -c 'import sys,json; x=json.load(sys.stdin); print x["system"]["destDir"]')
+app_name=$(cat ../../module.json | python -c 'import sys,json; x=json.load(sys.stdin); print x["name"]')
 
 unamestr=`uname`
 
@@ -43,8 +39,8 @@ fi
 
 if [[ "$device" =~ "6001" ]]; then
     echo "Compatible FTDI device found"
-    spinner &
-    spinner_pid=$!
+    progress &
+    progress_pid=$!
     disown
 else
     echo "No compatible FTDI device found" 1>&2
@@ -58,7 +54,7 @@ fi
 if [[ "$name" = *.itb ]]; then
     path="/upgrade"
     is_upgrade=1
-elif [[ "$name" != "$project" ]]; then
+elif [[ "$name" != "$app_name" ]]; then
     path="$dest_dir"
 else
     path="/home/usr/bin"
@@ -78,6 +74,7 @@ expect {
     "~ #" break
     timeout 5 goto end
 }
+timeout 3600
 send "mkdir -p $path"
 send "cd $path"
 send "rm $name"
@@ -107,7 +104,7 @@ fi
 # Cleanup
 rm send.tmp
 stty sane
-kill $spinner_pid
+kill $progress_pid
 
 # Print exec time
 end=$(date +%s)

--- a/targets/target-kubos-linux-isis-gcc/minicom/flash.sh
+++ b/targets/target-kubos-linux-isis-gcc/minicom/flash.sh
@@ -58,8 +58,8 @@ fi
 if [[ "$name" = *.itb ]]; then
     path="/upgrade"
     is_upgrade=1
-else if [[ "$name" != "$project" ]]; then
-    path="$destDir"
+elif [[ "$name" != "$project" ]]; then
+    path="$dest_dir"
 else
     path="/home/usr/bin"
 fi
@@ -78,7 +78,7 @@ expect {
     "~ #" break
     timeout 5 goto end
 }
-send "mkdir $path"
+send "mkdir -p $path"
 send "cd $path"
 send "rm $name"
 send "rz -bZ"

--- a/targets/target-kubos-linux-isis-gcc/minicom/flash.sh
+++ b/targets/target-kubos-linux-isis-gcc/minicom/flash.sh
@@ -78,8 +78,8 @@ timeout 3600
 send "mkdir -p $path"
 send "cd $path"
 send "rm $name"
-send "rz -bZ"
-! sz -b --zmodem $1
+send "rz -w 8192"
+! sz -w 8192 $1
 if $is_upgrade = 1 send "fw_setenv kubos_updatefile $name"
 send "exit"
 end:

--- a/targets/target-kubos-linux-isis-gcc/target.json
+++ b/targets/target-kubos-linux-isis-gcc/target.json
@@ -30,6 +30,7 @@
       "arm": {}
     },
     "system": {
+      "destDir": "/home/usr/local/bin1",
       "password": "Kubos123"
     }
   },

--- a/targets/target-kubos-linux-isis-gcc/target.json
+++ b/targets/target-kubos-linux-isis-gcc/target.json
@@ -30,7 +30,7 @@
       "arm": {}
     },
     "system": {
-      "destDir": "/home/usr/local/bin1",
+      "destDir": "/home/usr/local/bin",
       "password": "Kubos123"
     }
   },


### PR DESCRIPTION
Added code to the iOBC flash script to allow us to detect and transfer non-application files.

I'm operating on the assumption that if the file requested for transfer does not match the project name, then it must not be the application binary. If so, then it will be transferred to the non-app directory location.

This destination can be customized by the user with a new config.json parameter "destDir". (I kind of dislike the variable name. Alternate suggestions would be appreciated)