### PR TITLE
KUBOS-398  Moving argument parsing into client

### DIFF
--- a/cmd-control-client/cmd-control-client/client.h
+++ b/cmd-control-client/cmd-control-client/client.h
@@ -20,16 +20,16 @@
 #include "tinycbor/cbor.h"
 
 
-bool encode_packet(CborDataWrapper *data_wrapper, CNCCommandPacket * packet);
+bool cnc_client_encode_packet(CborDataWrapper *data_wrapper, CNCCommandPacket * packet);
 
-bool encode_command(CborDataWrapper * data_wrapper, CNCCommandPacket * packet, CborEncoder * encoder, CborEncoder * container);
+bool cnc_client_encode_command(CborDataWrapper * data_wrapper, CNCCommandPacket * packet, CborEncoder * encoder, CborEncoder * container);
 
-bool start_encode_response(int message_type, CborDataWrapper * data_wrapper, CNCCommandPacket * packet);
+bool cnc_client_start_encode_response(int message_type, CborDataWrapper * data_wrapper, CNCCommandPacket * packet);
 
-bool finish_encode_response_and_send(CborDataWrapper * data_wrapper, CborEncoder *encoder, CborEncoder * container);
+bool cnc_client_finish_encode_response_and_send(CborDataWrapper * data_wrapper, CborEncoder *encoder, CborEncoder * container);
 
-bool parse_processing_error(CborParser * parser, CborValue * map);
+bool cnc_client_parse_processing_error(CborParser * parser, CborValue * map);
 
-bool parse_command_result( CborParser * parser, CborValue * map);
+bool cnc_client_parse_command_result( CborParser * parser, CborValue * map);
 
-bool parse (CNCCommandPacket * command_packet, int argc, char ** argv);
+bool cnc_client_parse (CNCCommandPacket * command_packet, int argc, char ** argv);

--- a/cmd-control-client/cmd-control-client/client.h
+++ b/cmd-control-client/cmd-control-client/client.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include "command-and-control/types.h"
+#include "tinycbor/cbor.h"
+
+
+bool encode_packet(CborDataWrapper *data_wrapper, CNCCommandPacket * packet);
+bool encode_command(CborDataWrapper * data_wrapper, CNCCommandPacket * packet, CborEncoder * encoder, CborEncoder * container);
+bool start_encode_response(int message_type, CborDataWrapper * data_wrapper, CNCCommandPacket * packet);
+bool finish_encode_response_and_send(CborDataWrapper * data_wrapper, CborEncoder *encoder, CborEncoder * container);

--- a/cmd-control-client/cmd-control-client/client.h
+++ b/cmd-control-client/cmd-control-client/client.h
@@ -26,7 +26,7 @@ bool cnc_client_encode_command(CborDataWrapper * data_wrapper, CNCCommandPacket 
 
 bool cnc_client_start_encode_response(int message_type, CborDataWrapper * data_wrapper, CNCCommandPacket * packet);
 
-bool cnc_client_finish_encode_response_and_send(CborDataWrapper * data_wrapper, CborEncoder *encoder, CborEncoder * container);
+bool cnc_client_finish_encode_response(CborDataWrapper * data_wrapper, CborEncoder *encoder, CborEncoder * container);
 
 bool cnc_client_parse_processing_error(CborParser * parser, CborValue * map);
 

--- a/cmd-control-client/cmd-control-client/client.h
+++ b/cmd-control-client/cmd-control-client/client.h
@@ -1,3 +1,19 @@
+/*
+* Copyright (C) 2017 Kubos Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
 #pragma once
 
 #include "command-and-control/types.h"
@@ -5,6 +21,15 @@
 
 
 bool encode_packet(CborDataWrapper *data_wrapper, CNCCommandPacket * packet);
+
 bool encode_command(CborDataWrapper * data_wrapper, CNCCommandPacket * packet, CborEncoder * encoder, CborEncoder * container);
+
 bool start_encode_response(int message_type, CborDataWrapper * data_wrapper, CNCCommandPacket * packet);
+
 bool finish_encode_response_and_send(CborDataWrapper * data_wrapper, CborEncoder *encoder, CborEncoder * container);
+
+bool parse_processing_error(CborParser * parser, CborValue * map);
+
+bool parse_command_result( CborParser * parser, CborValue * map);
+
+bool parse (CNCCommandPacket * command_packet, int argc, char ** argv);

--- a/cmd-control-client/source/command.c
+++ b/cmd-control-client/source/command.c
@@ -1,0 +1,115 @@
+/*
+* Copyright (C) 2017 Kubos Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include <stdlib.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "command-and-control/types.h"
+#include "cmd-control-client/client.h"
+#include "tinycbor/cbor.h"
+
+
+bool encode_packet(CborDataWrapper * data_wrapper, CNCCommandPacket * packet)
+{
+    start_encode_response(MESSAGE_TYPE_COMMAND_INPUT, data_wrapper, packet);
+}
+
+
+bool start_encode_response(int message_type, CborDataWrapper * data_wrapper, CNCCommandPacket * packet)
+{
+    CborEncoder encoder, container;
+    CborError err;
+
+    if (packet == NULL)
+    {
+        return false;
+    }
+
+    cbor_encoder_init(&encoder, data_wrapper->data, MTU, 0);
+    err = cbor_encoder_create_map(&encoder, &container, 6); //TODO: Dynamically assign map size
+    if (err)
+    {
+        return false;
+    }
+
+    err = cbor_encode_text_stringz(&container, "MSG_TYPE");
+    if (err || cbor_encode_int(&container, message_type))
+    {
+        return false;
+    }
+
+    switch (message_type)
+    {
+        case MESSAGE_TYPE_COMMAND_INPUT:
+            return encode_command(data_wrapper, packet, &encoder, &container);
+            break;
+    }
+}
+
+
+bool encode_command(CborDataWrapper * data_wrapper, CNCCommandPacket * packet, CborEncoder * encoder, CborEncoder * container)
+{
+    CborError err;
+
+    if(data_wrapper == NULL || packet == NULL)
+    {
+        return false;
+    }
+
+    err = cbor_encode_text_stringz(container, "ACTION");
+    if (err || cbor_encode_int(container, (int)packet->action))
+    {
+        return false;
+    }
+
+    err = cbor_encode_text_stringz(container, "ARG_COUNT");
+    if (err || cbor_encode_int(container, packet->arg_count))
+    {
+        return false;
+    }
+
+    err = cbor_encode_text_stringz(container, "COMMAND_NAME");
+    if (err || cbor_encode_text_stringz(container, packet->cmd_name))
+    {
+        return false;
+    }
+
+    //TODO:Encode multiple args
+    err = cbor_encode_text_stringz(container, "ARGS");
+    if (err || cbor_encode_text_stringz(container, packet->args[0]))
+    {
+        return false;
+    }
+
+    return finish_encode_response_and_send(data_wrapper, encoder, container);
+}
+
+
+bool finish_encode_response_and_send(CborDataWrapper * data_wrapper, CborEncoder *encoder, CborEncoder * container)
+{
+    if (data_wrapper == NULL)
+    {
+        return false;
+    }
+
+    cbor_encoder_close_container(encoder, container);
+    data_wrapper->length = cbor_encoder_get_buffer_size(encoder, data_wrapper->data);
+    /*printf("Data: %s\n", data_wrapper->data);*/
+    return true;
+}
+

--- a/cmd-control-client/source/command.c
+++ b/cmd-control-client/source/command.c
@@ -35,7 +35,7 @@ bool start_encode_response(int message_type, CborDataWrapper * data_wrapper, CNC
     CborEncoder encoder, container;
     CborError err;
 
-    if (packet == NULL)
+    if (data_wrapper == NULL || packet == NULL)
     {
         return false;
     }

--- a/cmd-control-client/source/command.c
+++ b/cmd-control-client/source/command.c
@@ -24,13 +24,13 @@
 #include "tinycbor/cbor.h"
 
 
-bool encode_packet(CborDataWrapper * data_wrapper, CNCCommandPacket * packet)
+bool cnc_client_encode_packet(CborDataWrapper * data_wrapper, CNCCommandPacket * packet)
 {
-    start_encode_response(MESSAGE_TYPE_COMMAND_INPUT, data_wrapper, packet);
+    cnc_client_start_encode_response(MESSAGE_TYPE_COMMAND_INPUT, data_wrapper, packet);
 }
 
 
-bool start_encode_response(int message_type, CborDataWrapper * data_wrapper, CNCCommandPacket * packet)
+bool cnc_client_start_encode_response(int message_type, CborDataWrapper * data_wrapper, CNCCommandPacket * packet)
 {
     CborEncoder encoder, container;
     CborError err;
@@ -56,13 +56,16 @@ bool start_encode_response(int message_type, CborDataWrapper * data_wrapper, CNC
     switch (message_type)
     {
         case MESSAGE_TYPE_COMMAND_INPUT:
-            return encode_command(data_wrapper, packet, &encoder, &container);
+            return cnc_client_encode_command(data_wrapper, packet, &encoder, &container);
+            break;
+        default:
+            fprintf(stderr, "Message type %i, Not found", message_type);
             break;
     }
 }
 
 
-bool encode_command(CborDataWrapper * data_wrapper, CNCCommandPacket * packet, CborEncoder * encoder, CborEncoder * container)
+bool cnc_client_encode_command(CborDataWrapper * data_wrapper, CNCCommandPacket * packet, CborEncoder * encoder, CborEncoder * container)
 {
     CborError err;
 
@@ -96,11 +99,11 @@ bool encode_command(CborDataWrapper * data_wrapper, CNCCommandPacket * packet, C
         return false;
     }
 
-    return finish_encode_response_and_send(data_wrapper, encoder, container);
+    return cnc_client_finish_encode_response_and_send(data_wrapper, encoder, container);
 }
 
 
-bool finish_encode_response_and_send(CborDataWrapper * data_wrapper, CborEncoder *encoder, CborEncoder * container)
+bool cnc_client_finish_encode_response_and_send(CborDataWrapper * data_wrapper, CborEncoder *encoder, CborEncoder * container)
 {
     if (data_wrapper == NULL)
     {
@@ -109,7 +112,7 @@ bool finish_encode_response_and_send(CborDataWrapper * data_wrapper, CborEncoder
 
     cbor_encoder_close_container(encoder, container);
     data_wrapper->length = cbor_encoder_get_buffer_size(encoder, data_wrapper->data);
-    /*printf("Data: %s\n", data_wrapper->data);*/
+
     return true;
 }
 

--- a/cmd-control-client/source/command.c
+++ b/cmd-control-client/source/command.c
@@ -41,7 +41,7 @@ bool cnc_client_start_encode_response(int message_type, CborDataWrapper * data_w
     }
 
     cbor_encoder_init(&encoder, data_wrapper->data, MTU, 0);
-    err = cbor_encoder_create_map(&encoder, &container, 6); //TODO: Dynamically assign map size
+    err = cbor_encoder_create_map(&encoder, &container, 5); //TODO: Dynamically assign map size
     if (err)
     {
         return false;
@@ -69,7 +69,7 @@ bool cnc_client_encode_command(CborDataWrapper * data_wrapper, CNCCommandPacket 
 {
     CborError err;
 
-    if(data_wrapper == NULL || packet == NULL)
+    if(data_wrapper == NULL || packet == NULL || encoder == NULL || container == NULL)
     {
         return false;
     }
@@ -99,13 +99,13 @@ bool cnc_client_encode_command(CborDataWrapper * data_wrapper, CNCCommandPacket 
         return false;
     }
 
-    return cnc_client_finish_encode_response_and_send(data_wrapper, encoder, container);
+    return cnc_client_finish_encode_response(data_wrapper, encoder, container);
 }
 
 
-bool cnc_client_finish_encode_response_and_send(CborDataWrapper * data_wrapper, CborEncoder *encoder, CborEncoder * container)
+bool cnc_client_finish_encode_response(CborDataWrapper * data_wrapper, CborEncoder * encoder, CborEncoder * container)
 {
-    if (data_wrapper == NULL)
+    if (data_wrapper == NULL || encoder == NULL || container == NULL)
     {
         return false;
     }

--- a/cmd-control-client/source/main.c
+++ b/cmd-control-client/source/main.c
@@ -96,8 +96,8 @@ bool init()
     int my_address = 2;
     char *rx_channel_name, *tx_channel_name;
 
-    tx_channel_name = "/home/vagrant/client_to_server";
-    rx_channel_name = "/home/vagrant/server_to_client";
+    tx_channel_name = "/home/vagrant/client-to-server";
+    rx_channel_name = "/home/vagrant/server-to-client";
 
 
     /* Init CSP and CSP buffer system */
@@ -130,27 +130,13 @@ bool init()
     return true;
 }
 
-//Where the magic happens - Bascially ignore everything above this line - The initialization is going to change a lot.
-/*bool init()*/
-/*{*/
-    /*if (!kubos_csp_init(CLI_CLIENT_ADDRESS))*/
-    /*{*/
-        /*return false;*/
-    /*}*/
-
-    /*csp_route_set(SERVER_CSP_ADDRESS, &csp_socket_if, CSP_NODE_MAC);*/
-
-    /*return true;*/
-/*}*/
-
+//Where the magic happens - End of the CSP FIFO setup code
 
 bool send_packet(csp_packet_t* packet)
 {
     csp_conn_t *conn;
 
     if (packet) {
-        /*socket_init(&socket_driver, CSP_SOCKET_CLIENT, SOCKET_PORT);*/
-        /*csp_socket_init(&csp_socket_if, &socket_driver);*/
 
         conn = csp_connect(CSP_PRIO_NORM, SERVER_CSP_ADDRESS, CSP_PORT, 1000, CSP_O_NONE);
 
@@ -175,6 +161,10 @@ bool send_msg(CborDataWrapper * data_wrapper)
 {
     csp_conn_t *conn;
     csp_packet_t *packet;
+    if (data_wrapper == NULL)
+    {
+        return false;
+    }
 
     if (packet = csp_buffer_get(data_wrapper->length))
     {
@@ -199,6 +189,11 @@ bool parse_response(csp_packet_t * packet)
     CborParser parser;
     CborValue map, element;
     int message_type;
+
+    if (packet == NULL)
+    {
+        return false;
+    }
 
     CborError err = cbor_parser_init((uint8_t*) packet->data, packet->length, 0, &parser, &map);
     if (err)
@@ -228,10 +223,10 @@ bool parse_response(csp_packet_t * packet)
 
 bool parse_command_result( CborParser * parser, CborValue * map)
 {
-    size_t len;
     uint8_t return_code;
     double execution_time;
     char output[BUF_SIZE];
+    size_t len = BUF_SIZE;
 
     CborValue element;
     CborError err;
@@ -263,8 +258,8 @@ bool parse_command_result( CborParser * parser, CborValue * map)
 
 bool parse_processing_error(CborParser * parser, CborValue * map)
 {
-    size_t len;
-    char error_message[BUF_SIZE];
+    size_t len = BUF_SIZE;
+    char error_message[BUF_SIZE] = {0};
     CborValue element;
     CborError err;
 

--- a/cmd-control-client/source/main.c
+++ b/cmd-control-client/source/main.c
@@ -40,18 +40,14 @@
 #define SERVER_CSP_ADDRESS 1
 #define SOCKET_PORT        8189
 
-bool parse_processing_error(CborParser * parser, CborValue * map);
-bool parse_command_result( CborParser * parser, CborValue * map);
-bool parse (CNCCommandPacket * command_packet, int argc, char ** argv);
-
 csp_iface_t csp_socket_if;
 csp_socket_handle_t socket_driver;
 
 
 /*
- * IMPORTANT: For review ignore everything before line #91
- * We won't be using named pipes and everything before that is all csp code to
- * set up a named pipe connection.
+ * IMPORTANT: CSP FIFO example setup code. The long term intetion is to move
+ * away from named pipes to the newer tcp communication mechanism. This is a
+ * temporary measure that will be removed once the new system is ready.
  */
 
 pthread_t rx_thread, my_thread;
@@ -145,12 +141,13 @@ bool send_packet(csp_packet_t* packet)
             csp_buffer_free(packet);
             return false;
         }
-        printf("Sending Packet:%s\n", packet);
+
         if (!csp_send(conn, packet, 1000))
         {
             csp_buffer_free(packet);
             return false;
         }
+
         csp_close(conn);
     }
     return true;
@@ -309,6 +306,8 @@ int main(int argc, char **argv)
     char args[BUF_SIZE] = {0};
     uint8_t data[BUF_SIZE] = {0};
 
+    //The CborDataWrapper keeps a reference to a buffer and the length of the
+    //buffer tied together and simplifies passing both pieces of data between functions
     CborDataWrapper data_wrapper;
     data_wrapper.length = 0;
     data_wrapper.data = data;

--- a/cmd-control-client/source/parser.c
+++ b/cmd-control-client/source/parser.c
@@ -57,7 +57,15 @@ unsigned long get_hash(char *str)
 
 bool set_action(char* arg, CNCCommandPacket * command_packet)
 {
-    unsigned long hash = get_hash(arg);
+    unsigned long hash;
+
+    if (command_packet == NULL)
+    {
+        return false;
+    }
+
+    hash = get_hash(arg);
+
     switch (hash)
     {
         case EXEC_HASH:
@@ -118,9 +126,11 @@ static int parse_opt (int key, char *arg, struct argp_state *state)
 bool parse (CNCCommandPacket * command_packet, int argc, char ** argv)
 {
     int res, argsc;
-
-    /*int flags = ARGP_PARSE_ARGV0 | ARGP_NO_ERRS;*/
     int flags = 0;
+    if (command_packet == NULL || argv == NULL)
+    {
+        return false;
+    }
 
     argp_parse (&argp, argc, argv, flags, 0, command_packet);
 

--- a/cmd-control-client/source/parser.c
+++ b/cmd-control-client/source/parser.c
@@ -1,0 +1,129 @@
+/*
+* Copyright (C) 2017 Kubos Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include <argp.h>
+#include <csp/csp.h>
+#include <stdio.h>
+#include <stdarg.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "command-and-control/types.h"
+
+//Action string hash values
+#define EXEC_HASH    6385204650
+#define HELP_HASH    6385292014
+#define OUTPUT_HASH  6953876217206
+#define STATUS_HASH  6954030894409
+
+static int parse_opt (int key, char *arg, struct argp_state *state);
+
+//This is required by argp and will be useful if we add options to the daemon.
+//An example option could be run a command but do not send the output or something like that.
+static struct argp_option options[] =
+{
+    {0}
+};
+
+static char args_doc[] = "Action Group-Name [following args]";
+static char doc[] = "CNC - Execute commands through the Kubos command and control framework";
+static struct argp argp = { options, parse_opt, args_doc, doc};
+
+
+//djb2 string hash function
+unsigned long get_hash(char *str)
+{
+    unsigned long hash = 5381;
+    int c;
+    while (c = *str++)
+        hash = ((hash << 5) + hash) + c;
+
+    return hash;
+}
+
+
+bool set_action(char* arg, CNCCommandPacket * command_packet)
+{
+    unsigned long hash = get_hash(arg);
+    switch (hash)
+    {
+        case EXEC_HASH:
+            command_packet->action = EXECUTE;
+            break;
+        case HELP_HASH:
+            command_packet->action = HELP;
+            break;
+        case OUTPUT_HASH:
+            command_packet->action = OUTPUT;
+            break;
+        case STATUS_HASH:
+            command_packet->action = STATUS;
+            break;
+        default:
+            fprintf(stderr, "Requested action: %s, is not available\n", arg);
+            return false;
+    }
+    return true;
+}
+
+
+static int parse_opt (int key, char *arg, struct argp_state *state)
+{
+    CNCCommandPacket * command_packet = state->input;
+    int idx;
+    switch (key)
+    {
+        case ARGP_KEY_ARG:
+            switch(command_packet->arg_count++)
+            {
+                case 0:
+                    if (!set_action(arg, command_packet))
+                    {
+                        state->next = state->argc; //Abort parsing the remaining args
+                    }
+                    break;
+                case 1:
+                    strcpy(command_packet->cmd_name, arg);
+                    break;
+                default:
+                    idx = command_packet->arg_count - 3; //3 because of the increment
+                    strcpy(command_packet->args[idx], arg);
+            }
+            break;
+        case ARGP_KEY_END:
+            if (strlen(command_packet->cmd_name) == 0) //TODO: Effectively validate the action
+            {
+                fprintf(stderr, "received incorrect command or action argument\n"); //Would be helpful to give the help message here..
+            }
+            command_packet->arg_count = command_packet->arg_count - 2;
+            break;
+    }
+    return 0;
+}
+
+
+bool parse (CNCCommandPacket * command_packet, int argc, char ** argv)
+{
+    int res, argsc;
+
+    /*int flags = ARGP_PARSE_ARGV0 | ARGP_NO_ERRS;*/
+    int flags = 0;
+
+    argp_parse (&argp, argc, argv, flags, 0, command_packet);
+
+    return true;
+}
+

--- a/cmd-control-client/source/parser.c
+++ b/cmd-control-client/source/parser.c
@@ -93,11 +93,27 @@ bool set_action(char* arg, CNCCommandPacket * command_packet)
 
 static int parse_opt(int key, char *arg, struct argp_state *state)
 {
-    CNCCommandPacket * command_packet = state->input;
+    CNCCommandPacket * command_packet;
     int idx;
+
+    //Delay NULL checking arg. This function is run a large number of times, some of which
+    //arg is NULL and it should be (ie. when the parser is initializing, finishing, etc).
+
+    if (state == NULL || state->input == NULL)
+    {
+        return 1;
+    }
+
+    command_packet = state->input;
+
     switch (key)
     {
         case ARGP_KEY_ARG:
+            if (arg == NULL)
+            {
+                return 1;
+            }
+
             switch(command_packet->arg_count++)
             {
                 case 0:

--- a/cmd-control-client/source/parser.c
+++ b/cmd-control-client/source/parser.c
@@ -111,7 +111,7 @@ static int parse_opt(int key, char *arg, struct argp_state *state)
         case ARGP_KEY_ARG:
             if (arg == NULL)
             {
-                return 1;
+                return ARGP_ERR_UNKNOWN;
             }
 
             switch(command_packet->arg_count++)

--- a/cmd-control-client/source/parser.c
+++ b/cmd-control-client/source/parser.c
@@ -24,6 +24,7 @@
 #include "command-and-control/types.h"
 
 //Action string hash values
+#define BASE_HASH    5381
 #define EXEC_HASH    6385204650
 #define HELP_HASH    6385292014
 #define OUTPUT_HASH  6953876217206
@@ -46,10 +47,12 @@ static struct argp argp = { options, parse_opt, args_doc, doc};
 //djb2 string hash function
 unsigned long get_hash(char *str)
 {
-    unsigned long hash = 5381;
+    unsigned long hash = BASE_HASH;
     int c;
     while (c = *str++)
+    {
         hash = ((hash << 5) + hash) + c;
+    }
 
     return hash;
 }
@@ -88,7 +91,7 @@ bool set_action(char* arg, CNCCommandPacket * command_packet)
 }
 
 
-static int parse_opt (int key, char *arg, struct argp_state *state)
+static int parse_opt(int key, char *arg, struct argp_state *state)
 {
     CNCCommandPacket * command_packet = state->input;
     int idx;
@@ -123,7 +126,7 @@ static int parse_opt (int key, char *arg, struct argp_state *state)
 }
 
 
-bool parse (CNCCommandPacket * command_packet, int argc, char ** argv)
+bool cnc_client_parse_cl_args(CNCCommandPacket * command_packet, int argc, char ** argv)
 {
     int res, argsc;
     int flags = 0;

--- a/cmd-control-client/source/parser.c
+++ b/cmd-control-client/source/parser.c
@@ -128,15 +128,22 @@ static int parse_opt(int key, char *arg, struct argp_state *state)
 
 bool cnc_client_parse_cl_args(CNCCommandPacket * command_packet, int argc, char ** argv)
 {
-    int res, argsc;
+    int result;
     int flags = 0;
     if (command_packet == NULL || argv == NULL)
     {
         return false;
     }
 
-    argp_parse (&argp, argc, argv, flags, 0, command_packet);
-
-    return true;
+    result = argp_parse (&argp, argc, argv, flags, 0, command_packet);
+    if (result == 0)
+    {
+        return true;
+    }
+    else
+    {
+        //Do some error handling
+        return false;
+    }
 }
 

--- a/cmd-control-daemon/cmd-control-daemon/daemon.h
+++ b/cmd-control-daemon/cmd-control-daemon/daemon.h
@@ -37,7 +37,6 @@ bool parse_buffer(CNCWrapper * wrapper, CborDataWrapper * data_wrapper);
 bool parse_buffer_from_packet(csp_packet_t * packet, CborDataWrapper * data_wrapper);
 
 bool parse_command(CborParser * parser, CborValue * map, CNCWrapper * wrapper);
-//bool parse_command_cbor(csp_packet_t * packet, char * command);
 
 bool load_and_run_command(CNCWrapper * wrapper);
 

--- a/cmd-control-daemon/cmd-control-daemon/daemon.h
+++ b/cmd-control-daemon/cmd-control-daemon/daemon.h
@@ -22,29 +22,29 @@
 
 typedef int (*lib_function)(int, char**);
 
-bool encode_processing_error(uint8_t * data, CNCWrapper * result, CborEncoder * encoder, CborEncoder * container);
+bool cnc_daemon_encode_processing_error(uint8_t * data, CNCWrapper * result, CborEncoder * encoder, CborEncoder * container);
 
-bool encode_response(uint8_t * data, CNCWrapper * wrapper, CborEncoder * encoder, CborEncoder * container);
+bool cnc_daemon_encode_response(uint8_t * data, CNCWrapper * wrapper, CborEncoder * encoder, CborEncoder * container);
 
-bool finish_encode_response_and_send(uint8_t * data, CborEncoder *encoder, CborEncoder * container);
+bool cnc_daemon_finish_encode_response_and_send(uint8_t * data, CborEncoder *encoder, CborEncoder * container);
 
-bool get_command(csp_socket_t* sock, char * command);
+bool cnc_daemon_get_command(csp_socket_t* sock, char * command);
 
-bool parse (char * args, CNCWrapper * my_arguments);
+bool cnc_daemon_parse (char * args, CNCWrapper * my_arguments);
 
-bool parse_buffer(CNCWrapper * wrapper, CborDataWrapper * data_wrapper);
+bool cnc_daemon_parse_buffer(CNCWrapper * wrapper, CborDataWrapper * data_wrapper);
 
-bool parse_buffer_from_packet(csp_packet_t * packet, CborDataWrapper * data_wrapper);
+bool cnc_daemon_parse_buffer_from_packet(csp_packet_t * packet, CborDataWrapper * data_wrapper);
 
-bool parse_command(CborParser * parser, CborValue * map, CNCWrapper * wrapper);
+bool cnc_daemon_parse_command(CborParser * parser, CborValue * map, CNCWrapper * wrapper);
 
-bool load_and_run_command(CNCWrapper * wrapper);
+bool cnc_daemon_load_and_run_command(CNCWrapper * wrapper);
 
-bool send_buffer(uint8_t * data, size_t data_len);
+bool cnc_daemon_send_buffer(uint8_t * data, size_t data_len);
 
-bool start_encode_response(int message_type, CNCWrapper * wrapper);
+bool cnc_daemon_start_encode_response(int message_type, CNCWrapper * wrapper);
 
-bool send_result(CNCWrapper * wrapper);
+bool cnc_daemon_send_result(CNCWrapper * wrapper);
 
 
 #ifdef YOTTA_CFG_CNC_DAEMON_CMD_STR_LEN

--- a/cmd-control-daemon/cmd-control-daemon/daemon.h
+++ b/cmd-control-daemon/cmd-control-daemon/daemon.h
@@ -32,7 +32,12 @@ bool get_command(csp_socket_t* sock, char * command);
 
 bool parse (char * args, CNCWrapper * my_arguments);
 
-bool parse_command_cbor(csp_packet_t * packet, char * command);
+bool parse_buffer(CNCWrapper * wrapper, CborDataWrapper * data_wrapper);
+
+bool parse_buffer_from_packet(csp_packet_t * packet, CborDataWrapper * data_wrapper);
+
+bool parse_command(CborParser * parser, CborValue * map, CNCWrapper * wrapper);
+//bool parse_command_cbor(csp_packet_t * packet, char * command);
 
 bool load_and_run_command(CNCWrapper * wrapper);
 

--- a/cmd-control-daemon/source/command.c
+++ b/cmd-control-daemon/source/command.c
@@ -27,7 +27,7 @@
 #define CBOR_BUF_SIZE YOTTA_CFG_CSP_MTU
 
 
-bool parse_command_cbor(csp_packet_t * packet, char * command)
+bool cnc_daemon_parse_command_cbor(csp_packet_t * packet, char * command)
 {
     CborParser parser;
     CborValue map, element;
@@ -58,7 +58,7 @@ bool file_exists(char * path) //Should this live in a higher level module utilit
 }
 
 
-bool load_command(CNCWrapper * wrapper, void ** handle, lib_function * func)
+bool cnc_daemon_load_command(CNCWrapper * wrapper, void ** handle, lib_function * func)
 {
     int return_code;
     char so_path[SO_PATH_LENGTH];
@@ -116,7 +116,7 @@ bool load_command(CNCWrapper * wrapper, void ** handle, lib_function * func)
 }
 
 
-bool run_command(CNCWrapper * wrapper, void ** handle, lib_function func)
+bool cnc_daemon_run_command(CNCWrapper * wrapper, void ** handle, lib_function func)
 {
     int original_stdout;
     //Redirect stdout to the response output field.
@@ -164,7 +164,7 @@ bool run_command(CNCWrapper * wrapper, void ** handle, lib_function func)
 }
 
 
-bool load_and_run_command(CNCWrapper * wrapper)
+bool cnc_daemon_load_and_run_command(CNCWrapper * wrapper)
 {
     void * handle;
 
@@ -175,23 +175,23 @@ bool load_and_run_command(CNCWrapper * wrapper)
 
     lib_function func = NULL;
 
-    if (!load_command(wrapper, &handle, &func))
+    if (!cnc_daemon_load_command(wrapper, &handle, &func))
     {
         printf("Failed to load command\n");
         wrapper->err = true;
-        send_result(wrapper);
+        cnc_daemon_send_result(wrapper);
         return false;
     }
-    if (!run_command(wrapper, &handle, func))
+    if (!cnc_daemon_run_command(wrapper, &handle, func))
     {
         printf("Failed to run command\n");
         wrapper->err = true;
-        send_result(wrapper);
+        cnc_daemon_send_result(wrapper);
         return false;
     }
 
     //Running the command succeeded
     printf("Command succeeded - Sending Result\n");
-    return send_result(wrapper);
+    return cnc_daemon_send_result(wrapper);
 }
 

--- a/cmd-control-daemon/source/command.c
+++ b/cmd-control-daemon/source/command.c
@@ -63,6 +63,11 @@ bool load_command(CNCWrapper * wrapper, void ** handle, lib_function * func)
     int return_code;
     char so_path[SO_PATH_LENGTH];
 
+    if (wrapper == NULL || handle == NULL || func == NULL)
+    {
+        return false;
+    }
+
     // so_len - the format specifier length (-2) + the null character (+1) leading to the -1
     int so_len = strlen(MODULE_REGISTRY_DIR) + strlen(wrapper->command_packet->cmd_name) - 1;
     snprintf(so_path, so_len, MODULE_REGISTRY_DIR, wrapper->command_packet->cmd_name);
@@ -113,10 +118,15 @@ bool load_command(CNCWrapper * wrapper, void ** handle, lib_function * func)
 
 bool run_command(CNCWrapper * wrapper, void ** handle, lib_function func)
 {
+    int original_stdout;
     //Redirect stdout to the response output field.
     //TODO: Redirect or figure out what to do with STDERR
 
-    int original_stdout;
+    if (wrapper == NULL || handle == NULL)
+    {
+        return false;
+    }
+
     fflush(stdout);
     original_stdout = dup(STDOUT_FILENO);
     freopen("/dev/null", "a", stdout);
@@ -156,8 +166,14 @@ bool run_command(CNCWrapper * wrapper, void ** handle, lib_function func)
 
 bool load_and_run_command(CNCWrapper * wrapper)
 {
-    lib_function func = NULL;
     void * handle;
+
+    if (wrapper == NULL)
+    {
+        return false;
+    }
+
+    lib_function func = NULL;
 
     if (!load_command(wrapper, &handle, &func))
     {

--- a/cmd-control-daemon/source/command.c
+++ b/cmd-control-daemon/source/command.c
@@ -33,6 +33,11 @@ bool cnc_daemon_parse_command_cbor(csp_packet_t * packet, char * command)
     CborValue map, element;
     size_t len;
 
+    if (packet == NULL || command == NULL)
+    {
+        return false;
+    }
+
     CborError err = cbor_parser_init((uint8_t*) packet->data, packet->length, 0, &parser, &map);
     if (err)
     {

--- a/cmd-control-daemon/source/main.c
+++ b/cmd-control-daemon/source/main.c
@@ -127,7 +127,7 @@ bool init()
 
 //Where the magic happens - End of the CSP FIFO setup code
 
-bool send_packet(csp_conn_t* conn, csp_packet_t* packet)
+bool cnc_daemon_send_packet(csp_conn_t* conn, csp_packet_t* packet)
 {
     if (conn == NULL || packet == NULL)
     {
@@ -143,7 +143,7 @@ bool send_packet(csp_conn_t* conn, csp_packet_t* packet)
 }
 
 
-bool send_buffer(uint8_t * data, size_t data_len)
+bool cnc_daemon_send_buffer(uint8_t * data, size_t data_len)
 {
     csp_socket_t *sock;
     csp_conn_t *conn;
@@ -160,7 +160,7 @@ bool send_buffer(uint8_t * data, size_t data_len)
         packet->length = data_len;
 
         conn = csp_connect(CSP_PRIO_NORM, CLI_CLIENT_ADDRESS, CSP_PORT, 1000, CSP_O_NONE);
-        if (!send_packet(conn, packet))
+        if (!cnc_daemon_send_packet(conn, packet))
         {
             csp_buffer_free(packet);
             csp_close(conn);
@@ -183,7 +183,7 @@ void zero_vars(char * command_str, CNCCommandPacket * command, CNCResponsePacket
     wrapper->err = false;
 }
 
-bool get_buffer(csp_socket_t* sock, CborDataWrapper * data_wrapper)
+bool cnc_daemon_get_buffer(csp_socket_t* sock, CborDataWrapper * data_wrapper)
 {
     csp_conn_t *conn;
     csp_packet_t *packet;
@@ -201,7 +201,7 @@ bool get_buffer(csp_socket_t* sock, CborDataWrapper * data_wrapper)
             packet = csp_read(conn, 0);
             if (packet)
             {
-                if (!parse_buffer_from_packet(packet, data_wrapper))
+                if (!cnc_daemon_parse_buffer_from_packet(packet, data_wrapper))
                 {
                     fprintf(stderr, "There was an error parsing the command packet\n");
                     csp_buffer_free(packet);
@@ -244,19 +244,19 @@ int main(int argc, char **argv)
     {
         zero_vars(command_str, &command, &response, &wrapper);
 
-        if (!get_buffer(sock, &data_wrapper))
+        if (!cnc_daemon_get_buffer(sock, &data_wrapper))
         {
             //Do some error handling
             continue;
         }
 
-        if (!parse_buffer(&wrapper, &data_wrapper))
+        if (!cnc_daemon_parse_buffer(&wrapper, &data_wrapper))
         {
             //Do some error handling
             continue;
         }
 
-        if(!load_and_run_command(&wrapper))
+        if(!cnc_daemon_load_and_run_command(&wrapper))
         {
             //Do some error handling
             continue;

--- a/cmd-control-daemon/source/main.c
+++ b/cmd-control-daemon/source/main.c
@@ -24,8 +24,8 @@
 #include <stdio.h>
 #include <string.h>
 #include <unistd.h>
+#include <csp/csp_debug.h>
 #include <csp/drivers/socket.h>
-#include <csp/interfaces/csp_if_socket.h>
 
 #include "command-and-control/types.h"
 #include "cmd-control-daemon/daemon.h"
@@ -43,16 +43,99 @@
 csp_iface_t csp_socket_if;
 csp_socket_handle_t socket_driver;
 
+
+/*
+ * IMPORTANT: For review ignore everything before line #91
+ * We won't be using named pipes and everything before that is all csp code to
+ * set up a named pipe connection.
+ */
+
+pthread_t rx_thread, my_thread;
+int rx_channel, tx_channel;
+
+int csp_fifo_tx(csp_iface_t *ifc, csp_packet_t *packet, uint32_t timeout);
+
+csp_iface_t csp_if_fifo =
+{
+    .name = "fifo",
+    .nexthop = csp_fifo_tx,
+    .mtu = MTU,
+};
+
+int csp_fifo_tx(csp_iface_t *ifc, csp_packet_t *packet, uint32_t timeout)
+{
+    /* Write packet to fifo */
+    if (write(tx_channel, &packet->length, packet->length + sizeof(uint32_t) + sizeof(uint16_t)) < 0)
+    {
+        printf("Failed to write frame\r\n");
+    }
+    csp_buffer_free(packet);
+    return CSP_ERR_NONE;
+}
+
+void * fifo_rx(void * parameters)
+{
+    csp_packet_t *buf = csp_buffer_get(BUF_SIZE);
+    /* Wait for packet on fifo */
+    while (read(rx_channel, &buf->length, BUF_SIZE) > 0)
+    {
+        csp_new_packet(buf, &csp_if_fifo, NULL);
+        buf = csp_buffer_get(BUF_SIZE);
+    }
+
+    return NULL;
+}
+
 bool init()
 {
-    if(!kubos_csp_init(SERVER_CSP_ADDRESS))
+
+    char *rx_channel_name, *tx_channel_name;
+
+    rx_channel_name = "/home/vagrant/client_to_server";
+    tx_channel_name = "/home/vagrant/server_to_client";
+
+
+    /* Init CSP and CSP buffer system */
+    if (csp_init(SERVER_CSP_ADDRESS) != CSP_ERR_NONE || csp_buffer_init(10, 300) != CSP_ERR_NONE)
     {
+        printf("Failed to init CSP\r\n");
         return false;
     }
 
-    csp_route_set(CLI_CLIENT_ADDRESS, &csp_socket_if, CSP_NODE_MAC);
-    csp_socket_init(&csp_socket_if, &socket_driver);
+    tx_channel = open(tx_channel_name, O_RDWR);
+    if (tx_channel < 0)
+    {
+        printf("Failed to open TX channel\r\n");
+        return false;
+    }
+
+    rx_channel = open(rx_channel_name, O_RDWR);
+    if (rx_channel < 0)
+    {
+        printf("Failed to open RX channel\r\n");
+        return false;
+    }
+
+    /* Start fifo RX task */
+    pthread_create(&rx_thread, NULL, fifo_rx, NULL);
+
+    /* Set default route and start router */
+    csp_route_set(CSP_DEFAULT_ROUTE, &csp_if_fifo, CSP_NODE_MAC);
+    csp_route_start_task(256, 1);
+    return true;
 }
+
+//Where the magic happens - Bascially ignore everything above this line - The initialization is going to change a lot.
+/*bool init()*/
+/*{*/
+    /*if(!kubos_csp_init(SERVER_CSP_ADDRESS))*/
+    /*{*/
+        /*return false;*/
+    /*}*/
+
+    /*csp_route_set(CLI_CLIENT_ADDRESS, &csp_socket_if, CSP_NODE_MAC);*/
+    /*csp_socket_init(&csp_socket_if, &socket_driver);*/
+/*}*/
 
 
 bool send_packet(csp_conn_t* conn, csp_packet_t* packet)
@@ -111,35 +194,37 @@ void zero_vars(char * command_str, CNCCommandPacket * command, CNCResponsePacket
     wrapper->err = false;
 }
 
-bool get_command(csp_socket_t* sock, char * command)
+bool get_buffer(csp_socket_t* sock, CborDataWrapper * data_wrapper)
 {
     csp_conn_t *conn;
     csp_packet_t *packet;
 
-    if (sock == NULL || command == NULL)
+    if (sock == NULL || data_wrapper == NULL)
     {
         return false;
     }
 
-    if (socket_init(&socket_driver, CSP_SOCKET_SERVER, SOCKET_PORT) != CSP_ERR_NONE)
-    {
-        return false;
-    }
+    /*if (socket_init(&socket_driver, CSP_SOCKET_SERVER, SOCKET_PORT) != CSP_ERR_NONE)*/
+    /*{*/
+        /*return false;*/
+    /*}*/
 
-    if (csp_socket_init(&csp_socket_if, &socket_driver) != CSP_ERR_NONE)
-    {
-        return false;
-    }
+    /*if (csp_socket_init(&csp_socket_if, &socket_driver) != CSP_ERR_NONE)*/
+    /*{*/
+        /*return false;*/
+    /*}*/
 
     while (1)
     {
         conn = csp_accept(sock, 1000);
         if (conn)
         {
+            printf("Reading packet\n");
             packet = csp_read(conn, 0);
             if (packet)
             {
-                if (!parse_command_cbor(packet, command))
+                printf("parsing packet\n");
+                if (!parse_buffer_from_packet(packet, data_wrapper))
                 {
                     fprintf(stderr, "There was an error parsing the command packet\n");
                     csp_buffer_free(packet);
@@ -155,10 +240,8 @@ bool get_command(csp_socket_t* sock, char * command)
 }
 
 
-
 int main(int argc, char **argv)
 {
-    int my_address = 1;
     csp_socket_t *sock;
     char command_str[CMD_STR_LEN];
     CNCCommandPacket command;
@@ -167,11 +250,13 @@ int main(int argc, char **argv)
     //any pre-run processing error messages that may occur
     CNCWrapper wrapper;
     bool exit = false;
-
+    uint8_t buffer[CMD_STR_LEN];
+    CborDataWrapper data_wrapper;
+    data_wrapper.data = buffer;
     wrapper.command_packet  = &command;
     wrapper.response_packet = &response;
 
-    init(my_address);
+    init();
     sock = csp_socket(CSP_SO_NONE);
     csp_bind(sock, CSP_PORT);
     csp_listen(sock, 5);
@@ -179,13 +264,15 @@ int main(int argc, char **argv)
     while (!exit)
     {
         zero_vars(command_str, &command, &response, &wrapper);
-        if (!get_command(sock, command_str))
+        printf("Getting buffer\n");
+        if (!get_buffer(sock, &data_wrapper))
         {
             //Do some error handling
             continue;
         }
 
-        if (!parse(command_str, &wrapper))
+        printf("Parsing Buffer\n");
+        if (!parse_buffer(&wrapper, &data_wrapper))
         {
             //Do some error handling
             continue;

--- a/cmd-control-daemon/source/main.c
+++ b/cmd-control-daemon/source/main.c
@@ -91,8 +91,8 @@ bool init()
 
     char *rx_channel_name, *tx_channel_name;
 
-    rx_channel_name = "/home/vagrant/client_to_server";
-    tx_channel_name = "/home/vagrant/server_to_client";
+    rx_channel_name = "/home/vagrant/client-to-server";
+    tx_channel_name = "/home/vagrant/server-to-client";
 
 
     /* Init CSP and CSP buffer system */
@@ -126,17 +126,6 @@ bool init()
 }
 
 //Where the magic happens - Bascially ignore everything above this line - The initialization is going to change a lot.
-/*bool init()*/
-/*{*/
-    /*if(!kubos_csp_init(SERVER_CSP_ADDRESS))*/
-    /*{*/
-        /*return false;*/
-    /*}*/
-
-    /*csp_route_set(CLI_CLIENT_ADDRESS, &csp_socket_if, CSP_NODE_MAC);*/
-    /*csp_socket_init(&csp_socket_if, &socket_driver);*/
-/*}*/
-
 
 bool send_packet(csp_conn_t* conn, csp_packet_t* packet)
 {
@@ -204,26 +193,14 @@ bool get_buffer(csp_socket_t* sock, CborDataWrapper * data_wrapper)
         return false;
     }
 
-    /*if (socket_init(&socket_driver, CSP_SOCKET_SERVER, SOCKET_PORT) != CSP_ERR_NONE)*/
-    /*{*/
-        /*return false;*/
-    /*}*/
-
-    /*if (csp_socket_init(&csp_socket_if, &socket_driver) != CSP_ERR_NONE)*/
-    /*{*/
-        /*return false;*/
-    /*}*/
-
     while (1)
     {
         conn = csp_accept(sock, 1000);
         if (conn)
         {
-            printf("Reading packet\n");
             packet = csp_read(conn, 0);
             if (packet)
             {
-                printf("parsing packet\n");
                 if (!parse_buffer_from_packet(packet, data_wrapper))
                 {
                     fprintf(stderr, "There was an error parsing the command packet\n");
@@ -264,14 +241,13 @@ int main(int argc, char **argv)
     while (!exit)
     {
         zero_vars(command_str, &command, &response, &wrapper);
-        printf("Getting buffer\n");
+
         if (!get_buffer(sock, &data_wrapper))
         {
             //Do some error handling
             continue;
         }
 
-        printf("Parsing Buffer\n");
         if (!parse_buffer(&wrapper, &data_wrapper))
         {
             //Do some error handling

--- a/cmd-control-daemon/source/main.c
+++ b/cmd-control-daemon/source/main.c
@@ -45,9 +45,9 @@ csp_socket_handle_t socket_driver;
 
 
 /*
- * IMPORTANT: For review ignore everything before line #91
- * We won't be using named pipes and everything before that is all csp code to
- * set up a named pipe connection.
+ * IMPORTANT: CSP FIFO example setup code. The long term intetion is to move
+ * away from named pipes to the newer tcp communication mechanism. This is a
+ * temporary measure that will be removed once the new system is ready.
  */
 
 pthread_t rx_thread, my_thread;
@@ -125,7 +125,7 @@ bool init()
     return true;
 }
 
-//Where the magic happens - Bascially ignore everything above this line - The initialization is going to change a lot.
+//Where the magic happens - End of the CSP FIFO setup code
 
 bool send_packet(csp_conn_t* conn, csp_packet_t* packet)
 {
@@ -228,6 +228,8 @@ int main(int argc, char **argv)
     CNCWrapper wrapper;
     bool exit = false;
     uint8_t buffer[CMD_STR_LEN];
+    //The CborDataWrapper keeps a reference to a buffer and the length of the
+    //buffer tied together and simplifies passing both pieces of data between functions
     CborDataWrapper data_wrapper;
     data_wrapper.data = buffer;
     wrapper.command_packet  = &command;

--- a/cmd-control-daemon/source/message.c
+++ b/cmd-control-daemon/source/message.c
@@ -19,7 +19,7 @@
 
 #include "cmd-control-daemon/daemon.h"
 
-bool send_result(CNCWrapper * wrapper)
+bool cnc_daemon_send_result(CNCWrapper * wrapper)
 {
     if (wrapper == NULL)
     {
@@ -28,16 +28,16 @@ bool send_result(CNCWrapper * wrapper)
 
     if (wrapper->err) //Thinking of changing the err flag to a state enum or similar multi-state member type
     {
-        start_encode_response(RESPONSE_TYPE_PROCESSING_ERROR, wrapper);
+        cnc_daemon_start_encode_response(RESPONSE_TYPE_PROCESSING_ERROR, wrapper);
     }
     else
     {
-        start_encode_response(RESPONSE_TYPE_COMMAND_RESULT, wrapper);
+        cnc_daemon_start_encode_response(RESPONSE_TYPE_COMMAND_RESULT, wrapper);
     }
 }
 
 
-bool start_encode_response(int message_type, CNCWrapper * wrapper)
+bool cnc_daemon_start_encode_response(int message_type, CNCWrapper * wrapper)
 {
     CborEncoder encoder, container;
     CborError err;
@@ -64,14 +64,14 @@ bool start_encode_response(int message_type, CNCWrapper * wrapper)
     switch (message_type)
     {
         case RESPONSE_TYPE_COMMAND_RESULT:
-            return encode_response(data, wrapper, &encoder, &container);
+            return cnc_daemon_encode_response(data, wrapper, &encoder, &container);
         case RESPONSE_TYPE_PROCESSING_ERROR:
-            return encode_processing_error(data, wrapper, &encoder, &container);
+            return cnc_daemon_encode_processing_error(data, wrapper, &encoder, &container);
     }
 }
 
 
-bool encode_response(uint8_t * data, CNCWrapper * wrapper, CborEncoder * encoder, CborEncoder * container)
+bool cnc_daemon_encode_response(uint8_t * data, CNCWrapper * wrapper, CborEncoder * encoder, CborEncoder * container)
 {
     CborError err;
 
@@ -98,11 +98,11 @@ bool encode_response(uint8_t * data, CNCWrapper * wrapper, CborEncoder * encoder
         return false;
     }
 
-    return finish_encode_response_and_send(data, encoder, container);
+    return cnc_daemon_finish_encode_response_and_send(data, encoder, container);
 }
 
 
-bool encode_processing_error(uint8_t * data, CNCWrapper * result, CborEncoder * encoder, CborEncoder * container)
+bool cnc_daemon_encode_processing_error(uint8_t * data, CNCWrapper * result, CborEncoder * encoder, CborEncoder * container)
 {
     CborError err;
 
@@ -117,11 +117,11 @@ bool encode_processing_error(uint8_t * data, CNCWrapper * result, CborEncoder * 
         return false;
     }
 
-    return finish_encode_response_and_send(data, encoder, container);
+    return cnc_daemon_finish_encode_response_and_send(data, encoder, container);
 }
 
 
-bool finish_encode_response_and_send(uint8_t * data, CborEncoder *encoder, CborEncoder * container)
+bool cnc_daemon_finish_encode_response_and_send(uint8_t * data, CborEncoder *encoder, CborEncoder * container)
 {
     if (data == NULL)
     {
@@ -130,6 +130,6 @@ bool finish_encode_response_and_send(uint8_t * data, CborEncoder *encoder, CborE
 
     cbor_encoder_close_container(encoder, container);
     size_t data_len = cbor_encoder_get_buffer_size(encoder, data);
-    return send_buffer(data, data_len);
+    return cnc_daemon_send_buffer(data, data_len);
 }
 

--- a/cmd-control-daemon/source/parser.c
+++ b/cmd-control-daemon/source/parser.c
@@ -18,7 +18,7 @@
 #include <tinycbor/cbor.h>
 #include "cmd-control-daemon/daemon.h"
 
-bool parse_buffer_from_packet(csp_packet_t * packet, CborDataWrapper * data_wrapper)
+bool cnc_daemon_parse_buffer_from_packet(csp_packet_t * packet, CborDataWrapper * data_wrapper)
 {
     if (packet == NULL || data_wrapper == NULL)
     {
@@ -29,7 +29,7 @@ bool parse_buffer_from_packet(csp_packet_t * packet, CborDataWrapper * data_wrap
     return true;
 }
 
-bool parse_buffer(CNCWrapper * wrapper, CborDataWrapper * data_wrapper)
+bool cnc_daemon_parse_buffer(CNCWrapper * wrapper, CborDataWrapper * data_wrapper)
 {
     CborParser parser;
     CborValue map, element;
@@ -50,7 +50,7 @@ bool parse_buffer(CNCWrapper * wrapper, CborDataWrapper * data_wrapper)
     switch (message_type)
     {
         case MESSAGE_TYPE_COMMAND_INPUT:
-            return parse_command(&parser, &map, wrapper);
+            return cnc_daemon_parse_command(&parser, &map, wrapper);
             break;
         default:
             fprintf(stderr, "Received unknown message type: %i\n", message_type);
@@ -59,7 +59,7 @@ bool parse_buffer(CNCWrapper * wrapper, CborDataWrapper * data_wrapper)
 }
 
 
-bool parse_command(CborParser * parser, CborValue * map, CNCWrapper * wrapper)
+bool cnc_daemon_parse_command(CborParser * parser, CborValue * map, CNCWrapper * wrapper)
 {
     size_t len;
     uint8_t return_code;

--- a/cmd-control-daemon/source/parser.c
+++ b/cmd-control-daemon/source/parser.c
@@ -14,156 +14,86 @@
 * limitations under the License.
 */
 
-#include <argp.h>
-#include <csp/csp.h>
-#include <stdio.h>
-#include <stdarg.h>
-#include <stdlib.h>
-#include <string.h>
-
-#include "command-and-control/types.h"
+#include <command-and-control/types.h>
+#include <tinycbor/cbor.h>
 #include "cmd-control-daemon/daemon.h"
 
-//Action string hash values
-#define EXEC_HASH    6385204650
-#define HELP_HASH    6385292014
-#define OUTPUT_HASH  6953876217206
-#define STATUS_HASH  6954030894409
-
-static int parse_opt (int key, char *arg, struct argp_state *state);
-
-//This is required by argp and will be useful if we add options to the daemon.
-//An example option could be run a command but do not send the output or something like that.
-static struct argp_option options[] =
+bool parse_buffer_from_packet(csp_packet_t * packet, CborDataWrapper * data_wrapper)
 {
-    {0}
-};
-
-static char args_doc[] = "Action Group-Name [following args]";
-static char doc[] = "CNC Daemon - Execute commands through the Kubos command and control framework";
-static struct argp argp = { options, parse_opt, args_doc, doc};
-
-
-//djb2 string hash function
-unsigned long get_hash(char *str)
-{
-    unsigned long hash = 5381;
-    int c;
-    while (c = *str++)
-        hash = ((hash << 5) + hash) + c;
-
-    return hash;
-}
-
-
-bool set_action(char* arg, CNCWrapper * wrapper)
-{
-    unsigned long hash = get_hash(arg);
-    switch (hash)
+    if (packet == NULL || data_wrapper == NULL)
     {
-        case EXEC_HASH:
-            wrapper->command_packet->action = EXECUTE;
-            break;
-        case HELP_HASH:
-            wrapper->command_packet->action = HELP;
-            break;
-        case OUTPUT_HASH:
-            wrapper->command_packet->action = OUTPUT;
-            break;
-        case STATUS_HASH:
-            wrapper->command_packet->action = STATUS;
-            break;
-        default:
-            snprintf(wrapper->output, sizeof(wrapper->output) - 1, "Requested action: %s, is not available\n", arg);
-            wrapper->err = true;
-            return false;
+        return false;
     }
+    data_wrapper->length = packet->length;
+    memcpy(data_wrapper->data, packet->data, data_wrapper->length);
     return true;
 }
 
-
-static int parse_opt (int key, char *arg, struct argp_state *state)
+bool parse_buffer(CNCWrapper * wrapper, CborDataWrapper * data_wrapper)
 {
-    CNCWrapper *arguments = state->input;
-    int idx;
-    switch (key)
+    CborParser parser;
+    CborValue map, element;
+    int message_type;
+
+    CborError err = cbor_parser_init(data_wrapper->data, data_wrapper->length, 0, &parser, &map);
+    if (err)
     {
-        case ARGP_KEY_ARG:
-            switch(arguments->command_packet->arg_count++)
-            {
-                case 0:
-                    if (!set_action(arg, arguments))
-                    {
-                        state->next = state->argc; //Abort parsing the remaining args
-                        send_result(arguments);
-                    }
-                    break;
-                case 1:
-                    strcpy(arguments->command_packet->cmd_name, arg);
-                    break;
-                default:
-                    idx = arguments->command_packet->arg_count - 3; //3 because of the increment
-                    strcpy(arguments->command_packet->args[idx], arg);
-            }
-            break;
-        case ARGP_KEY_END:
-            if (strlen(arguments->command_packet->cmd_name) == 0) //TODO: Effectively validate the action
-            {
-                arguments->err = true;
-                snprintf(arguments->output, sizeof(arguments->output) - 1, "received incorrect command or action argument\n"); //Would be helpful to give the help message here..
-                send_result(arguments);
-            }
-            arguments->command_packet->arg_count = arguments->command_packet->arg_count - 2;
-            break;
+        return false;
     }
-    return 0;
+
+    err = cbor_value_map_find_value(&map, "MSG_TYPE", &element);
+    if (err || cbor_value_get_int(&element, &message_type))
+    {
+        return false;
+    }
+
+    switch (message_type)
+    {
+        case MESSAGE_TYPE_COMMAND_INPUT:
+            return parse_command(&parser, &map, wrapper);
+            break;
+        default:
+            fprintf(stderr, "Received unknown message type: %i\n", message_type);
+            return false;
+   }
 }
 
 
-int get_num_args(char* string)
+bool parse_command(CborParser * parser, CborValue * map, CNCWrapper * wrapper)
 {
-    int count = 0, i = 1;
-    while (string[i++])
+    size_t len;
+    uint8_t return_code;
+    double execution_time;
+    char output[MTU];
+
+    CborValue element;
+    CborError err;
+    int i;
+    err = cbor_value_map_find_value(map, "ACTION", &element);
+    if (err || cbor_value_get_int(&element, &i))
     {
-        if (string[i] == ' ')
-        {
-            count++;
-        }
+        return false;
     }
-    return count + 1;
-}
+    wrapper->command_packet->action = (CNCAction) i;
 
-
-
-bool parse (char * args, CNCWrapper * wrapper)
-{
-    int res, argsc;
-    char * sub_str;
-    char * tok = " ";
-    int idx = 0;
-
-    wrapper->command_packet->arg_count = 0;
-
-    int my_argc = get_num_args(args);
-    //TODO: statically allocate and make it play nicely with argp
-    char ** result = malloc(sizeof(char*) * my_argc);
-
-    //Splitting string to gernerate an "argc, **argv" to pass into the argument parser.
-    sub_str = strtok (args, tok);
-    while (sub_str != NULL)
+    err = cbor_value_map_find_value(map, "ARG_COUNT", &element);
+    if (err || cbor_value_get_int(&element, &(wrapper->command_packet->arg_count)))
     {
-        result[idx++] = sub_str;
-        sub_str = strtok (NULL, tok);
+        return false;
     }
 
-    int flags = ARGP_PARSE_ARGV0 | ARGP_NO_ERRS;
+    err = cbor_value_map_find_value(map, "COMMAND_NAME", &element);
+    if (err || cbor_value_copy_text_string(&element, &(wrapper->command_packet->cmd_name), &len, NULL))
+    {
+        return false;
+    }
 
-    argp_parse (&argp, my_argc, result, flags, 0, wrapper);
-    free(result);
-    if (wrapper->err)
+    err = cbor_value_map_find_value(map, "ARGS", &element);
+    if (err || cbor_value_copy_text_string(&element, &(wrapper->command_packet->args[0]), &len, NULL))
     {
         return false;
     }
     return true;
+
 }
 

--- a/command-and-control/command-and-control/types.h
+++ b/command-and-control/command-and-control/types.h
@@ -14,11 +14,11 @@
 * limitations under the License.
 */
 
-#ifndef CNC_TYPES_H
-#define CNC_TYPES_H
+#pragma once
 
 #include <stdint.h>
 #include <stdbool.h>
+#include <stdlib.h>
 
 #define LIB_FORMAT_STR "/lib%s.so"
 
@@ -79,8 +79,9 @@
 #define RES_PACKET_STDOUT_LEN     MTU - CMD_PACKET_MEMBER_SIZE
 #endif
 
-#define RESPONSE_TYPE_COMMAND_RESULT 0
-#define RESPONSE_TYPE_PROCESSING_ERROR 1
+#define MESSAGE_TYPE_COMMAND_INPUT      0
+#define RESPONSE_TYPE_COMMAND_RESULT    1
+#define RESPONSE_TYPE_PROCESSING_ERROR  2
 
 
 typedef enum
@@ -118,4 +119,10 @@ typedef struct
     char output[RES_PACKET_STDOUT_LEN];
 } CNCWrapper;
 
-#endif
+//The CborDataWrapper keeps the length and buffer data together.
+typedef struct
+{
+    size_t    length;
+    uint8_t * data;
+} CborDataWrapper;
+


### PR DESCRIPTION
The goal of this is to simplify the functionality of the daemon significantly and remove some of the ugly things needed to make the daemon work originally.

This is using the csp fifo interface through named pipes temporarily. This is not ideal, they are only for testing. **They will be removed before review is requested for this PR!** 

 - [x]  Move parsing from daemon into client
 - [x]  Define new Api for sending "Parsed data" into the daemon
 - [x]  Parse the new input data format in the daemon
