### PR TITLE
Add missing similar-to keyword for the linux target.

### DIFF
--- a/targets/target-kubos-linux-isis-gcc/target.json
+++ b/targets/target-kubos-linux-isis-gcc/target.json
@@ -20,6 +20,7 @@
   ],
   "similarTo": [
     "linux",
+    "kubos-linux",
     "isis",
     "arm-linux-gcc",
     "arm"


### PR DESCRIPTION
This is a super simple addition to the isis target that was left out. This is included in the `x86-linux-native` [target](https://github.com/kubostech/kubos/blob/master/targets/target-x86-linux-native/target.json#L8). This allows target dependencies to apply for all linux targets without having to change the target dependency hierarchy.