### PR TITLE
KUBOS-414 Moving daemon specific defines out of the command-and-control into daemon. Misc fixes for running on the iOBC

### DIFF
--- a/cmd-control-client/config.json
+++ b/cmd-control-client/config.json
@@ -1,4 +1,8 @@
 {
+    "cnc": {
+        "client_tx_pipe": "\"/usr/local/kubos/client-to-server\"",
+        "client_rx_pipe": "\"/usr/local/kubos/server-to-client\""
+    },
     "csp": {
         "socket": true
     }

--- a/cmd-control-client/source/main.c
+++ b/cmd-control-client/source/main.c
@@ -40,6 +40,9 @@
 #define SERVER_CSP_ADDRESS 1
 #define SOCKET_PORT        8189
 
+#define CNC_CLIENT_RX_PIPE YOTTA_CFG_CNC_CLIENT_RX_PIPE
+#define CNC_CLIENT_TX_PIPE YOTTA_CFG_CNC_CLIENT_TX_PIPE
+
 csp_iface_t csp_socket_if;
 csp_socket_handle_t socket_driver;
 
@@ -92,8 +95,8 @@ bool init()
     int my_address = 2;
     char *rx_channel_name, *tx_channel_name;
 
-    tx_channel_name = "/home/vagrant/client-to-server";
-    rx_channel_name = "/home/vagrant/server-to-client";
+    tx_channel_name = CNC_CLIENT_TX_PIPE;
+    rx_channel_name = CNC_CLIENT_RX_PIPE;
 
 
     /* Init CSP and CSP buffer system */

--- a/cmd-control-daemon/cmd-control-daemon/daemon.h
+++ b/cmd-control-daemon/cmd-control-daemon/daemon.h
@@ -47,6 +47,16 @@ bool cnc_daemon_start_encode_response(int message_type, CNCWrapper * wrapper);
 bool cnc_daemon_send_result(CNCWrapper * wrapper);
 
 
+#define LIB_FORMAT_STR "/lib%s.so"
+
+#ifndef YOTTA_CFG_CNC_REGISTRY_DIR
+#define CNC_REGISTRY_DIR "/root"
+#else
+#define CNC_REGISTRY_DIR YOTTA_CFG_CNC_REGISTRY_DIR
+#endif
+
+#define MODULE_REGISTRY_DIR CNC_REGISTRY_DIR LIB_FORMAT_STR
+
 #ifdef YOTTA_CFG_CNC_DAEMON_CMD_STR_LEN
 #define CMD_STR_LEN YOTTA_CFG_CNC_DAEMON_CMD_STR_LEN
 #else
@@ -62,6 +72,6 @@ bool cnc_daemon_send_result(CNCWrapper * wrapper);
 #ifdef YOTTA_CFG_CNC_DAEMON_LOG_PATH
 #define DAEMON_LOG_PATH YOTTA_CFG_CNC_DAEMON_LOG_PATH
 #else
-#define DAEMON_LOG_PATH "/home/vagrant/daemon.log" //Only a dev path for now
+#define DAEMON_LOG_PATH "/var/log/daemon.log"
 #endif
 

--- a/cmd-control-daemon/config.json
+++ b/cmd-control-daemon/config.json
@@ -1,6 +1,9 @@
 {
     "cnc": {
-        "registry_dir": "\"/home/vagrant\""
+        "daemon_log_path": "\"/var/log.daemon.log\"",
+        "registry_dir": "\"/usr/local/kubos\"",
+        "daemon_rx_pipe": "\"/home/vagrant/client-to-server\"",
+        "daemon_tx_pipe": "\"/home/vagrant/server-to-client\""
     },
     "csp": {
         "socket": true

--- a/cmd-control-daemon/config.json
+++ b/cmd-control-daemon/config.json
@@ -1,6 +1,6 @@
 {
     "cnc": {
-        "daemon_log_path": "\"/var/log.daemon.log\"",
+        "daemon_log_path": "\"/home/var/log.daemon.log\"",
         "registry_dir": "\"/usr/local/kubos\"",
         "daemon_rx_pipe": "\"/usr/local/kubos/client-to-server\"",
         "daemon_tx_pipe": "\"/usr/local/kubos/server-to-client\""

--- a/cmd-control-daemon/config.json
+++ b/cmd-control-daemon/config.json
@@ -2,8 +2,8 @@
     "cnc": {
         "daemon_log_path": "\"/var/log.daemon.log\"",
         "registry_dir": "\"/usr/local/kubos\"",
-        "daemon_rx_pipe": "\"/home/vagrant/client-to-server\"",
-        "daemon_tx_pipe": "\"/home/vagrant/server-to-client\""
+        "daemon_rx_pipe": "\"/usr/local/kubos/client-to-server\"",
+        "daemon_tx_pipe": "\"/usr/local/kubos/server-to-client\""
     },
     "csp": {
         "socket": true

--- a/cmd-control-daemon/source/main.c
+++ b/cmd-control-daemon/source/main.c
@@ -41,6 +41,9 @@
 #define CLI_CLIENT_ADDRESS 2
 #define SOCKET_PORT        8189
 
+#define CNC_DAEMON_RX_PIPE YOTTA_CFG_CNC_DAEMON_RX_PIPE
+#define CNC_DAEMON_TX_PIPE YOTTA_CFG_CNC_DAEMON_TX_PIPE
+
 csp_iface_t csp_socket_if;
 csp_socket_handle_t socket_driver;
 
@@ -92,8 +95,8 @@ bool init()
 
     char *rx_channel_name, *tx_channel_name;
 
-    rx_channel_name = "/home/vagrant/client-to-server";
-    tx_channel_name = "/home/vagrant/server-to-client";
+    rx_channel_name = CNC_DAEMON_RX_PIPE;
+    tx_channel_name = CNC_DAEMON_TX_PIPE;
 
 
     /* Init CSP and CSP buffer system */

--- a/command-and-control/command-and-control/types.h
+++ b/command-and-control/command-and-control/types.h
@@ -20,16 +20,6 @@
 #include <stdbool.h>
 #include <stdlib.h>
 
-#define LIB_FORMAT_STR "/lib%s.so"
-
-#ifndef YOTTA_CFG_CNC_REGISTRY_DIR
-#define CNC_REGISTRY_DIR "~"
-#else
-#define CNC_REGISTRY_DIR YOTTA_CFG_CNC_REGISTRY_DIR
-#endif
-
-#define MODULE_REGISTRY_DIR CNC_REGISTRY_DIR LIB_FORMAT_STR
-
 #define DEFAULT_STR_LEN 20
 
 #ifdef YOTTA_CFG_CSP_MTU

--- a/commands/Makefile
+++ b/commands/Makefile
@@ -1,6 +1,12 @@
 # Makefile template for shared library
+# Run `make target="iobc" to build for the iboc
 
-CC = gcc # C compiler
+ifeq ($(target),iobc)
+	CC:=arm-linux-gcc
+else
+	CC:=gcc # C compiler
+endif
+
 INCLUDE := -Iinclude #include directories
 CFLAGS = -fPIC -Wall -Wextra -g $(INCLUDE) # C flags
 LDFLAGS = -shared  # linking flags


### PR DESCRIPTION
This:
* Removes a couple of hard coded dev paths
* Moves some daemon specific defines out of the command-and-control module, and into the daemon
* Adds Config.jsons specific for getting the command and control framework running on the iOBC.