### PR TITLE
KUBOS-416 Continuous Delivery configuration for CircleCI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -9,3 +9,9 @@ dependencies:
 test:
   override:
       - docker run -t --env CIRCLE_BRANCH=$CIRCLE_BRANCH -v $PWD:$PWD kubostech/kubos-dev:latest python $PWD/test/integration/integration_test.py
+
+deployment:
+  prod:
+    branch: master
+      commands:
+        - ./deploy.sh

--- a/circle.yml
+++ b/circle.yml
@@ -11,7 +11,7 @@ test:
       - docker run -t --env CIRCLE_BRANCH=$CIRCLE_BRANCH -v $PWD:$PWD kubostech/kubos-dev:latest python $PWD/test/integration/integration_test.py
 
 deployment:
-  prod:
+  production:
     branch: master
-      commands:
-        - ./deploy.sh
+    commands:
+      - ./deploy.sh

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,34 @@
+#! /bin/bash
+
+latest_tag=`git tag --sort=-creatordate | head -n 1`
+new_build_field=".1"
+
+echo "Latest tag: $latest_tag"
+
+#Stable releases follow major.minor.patch version format
+major_regex='^[0-9]+\.[0-9]+\.[0-9]$'
+#Unstable (CD) releases follow major.minor.patch.build version format
+build_regex='^[0-9]+\.[0-9]+\.[0-9]\.[0-9]$'
+
+if [[ $latest_tag =~ $major_regex ]];
+then
+    echo "The latest tag is a stable release. Adding a 'build' field to the version..."
+    new_tag="$latest_tag$new_build_field"
+elif [[ $latest_tag =~ $build_regex ]];
+then
+    echo "The latest tag is a CI/CD release. Incrementing the build version field..."
+    version_list=(`echo $latest_tag | tr '.' ' '`)
+    v_major=${version_list[0]}
+    v_minor=${version_list[1]}
+    v_patch=${version_list[2]}
+    v_build=${version_list[3]}
+    ((v_build+=1))
+    echo "BUild number is $v_build"
+    new_tag="$v_major.$v_minor.$v_patch.$v_build"
+fi
+
+echo "Tagging new verson: $new_tag"
+git tag $new_tag
+
+echo "Pushing new tag..."
+#git push origin --tags

--- a/deploy.sh
+++ b/deploy.sh
@@ -23,7 +23,6 @@ then
     v_patch=${version_list[2]}
     v_build=${version_list[3]}
     ((v_build+=1))
-    echo "BUild number is $v_build"
     new_tag="$v_major.$v_minor.$v_patch.$v_build"
 fi
 
@@ -31,4 +30,4 @@ echo "Tagging new verson: $new_tag"
 git tag $new_tag
 
 echo "Pushing new tag..."
-#git push origin --tags
+git push origin --tags


### PR DESCRIPTION
This should create a new CD tag. 

CD tags contains a build field in the version number ie. Major.Minor.Patch.Build

Stable releases follow the shorter Major.Minor.Patch versioning scheme. 