### PR TITLE
Pushing only the new tag rather than all tags in the CD deploy script

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -30,4 +30,4 @@ echo "Tagging new verson: $new_tag"
 git tag $new_tag
 
 echo "Pushing new tag..."
-git push origin --tags
+git push origin $new_tag


### PR DESCRIPTION
This should only push the new CD tag and prevent any janky tag conflicts like [build 171](https://circleci.com/gh/kubostech/kubos/171) 