### PR TITLE
KUBOS-457 Removing library command interface

### DIFF
--- a/cmd-control-client/source/command.c
+++ b/cmd-control-client/source/command.c
@@ -74,12 +74,6 @@ bool cnc_client_encode_command(CborDataWrapper * data_wrapper, CNCCommandPacket 
         return false;
     }
 
-    err = cbor_encode_text_stringz(container, "ACTION");
-    if (err || cbor_encode_int(container, (int)packet->action))
-    {
-        return false;
-    }
-
     err = cbor_encode_text_stringz(container, "ARG_COUNT");
     if (err || cbor_encode_int(container, packet->arg_count))
     {

--- a/cmd-control-daemon/source/parser.c
+++ b/cmd-control-daemon/source/parser.c
@@ -87,20 +87,6 @@ bool cnc_daemon_parse_command(CborParser * parser, CborValue * map, CNCWrapper *
         return false;
     }
 
-    if (err = cbor_value_map_find_value(map, "ACTION", &element))
-    {
-        KLOG_ERR(&log_handle, LOG_COMPONENT_NAME, "Unable to parse key ACTION. Error code: %i\n", err);
-        return false;
-    }
-
-    if (err = cbor_value_get_int(&element, &i))
-    {
-        KLOG_ERR(&log_handle, LOG_COMPONENT_NAME, "Unable to parse value for key ACTION. Error code: %i\n", err);
-        return false;
-    }
-
-    wrapper->command_packet->action = (CNCAction) i;
-
     if (err = cbor_value_map_find_value(map, "ARG_COUNT", &element))
     {
         KLOG_ERR(&log_handle, LOG_COMPONENT_NAME, "Unable to find key ARG_COUNT. Error code: %i\n", err);

--- a/command-and-control/command-and-control/types.h
+++ b/command-and-control/command-and-control/types.h
@@ -61,7 +61,7 @@
 
 //The size of all the members of the command packet, except the output field
 //The packet must fit into the CSP MTU or bad things will happen
-#define CMD_PACKET_MEMBER_SIZE sizeof(int) + sizeof(CNCAction) + CMD_PACKET_CMD_NAME_LEN
+#define CMD_PACKET_MEMBER_SIZE sizeof(int) + CMD_PACKET_CMD_NAME_LEN
 
 #ifdef YOTTA_CFG_CNC_RES_PACKET_STDOUT_LEN
 #define RES_PACKET_STDOUT_LEN        YOTTA_CFG_CNC_CMD_PACKET_ARG_LEN
@@ -73,20 +73,9 @@
 #define RESPONSE_TYPE_COMMAND_RESULT    1
 #define RESPONSE_TYPE_PROCESSING_ERROR  2
 
-
-typedef enum
-{
-    EXECUTE = 0,
-    STATUS,
-    OUTPUT,
-    HELP
-} CNCAction;
-
-
 typedef struct arguments
 {
     int arg_count;
-    CNCAction action;
     char cmd_name[CMD_PACKET_CMD_NAME_LEN];
     char args[CMD_PACKET_NUM_ARGS][CMD_PACKET_ARG_LEN];
 } CNCCommandPacket;


### PR DESCRIPTION
This is the last bit of functionality to remove the library specific bits from C&C and get it running with the simplified executable interface. 