### PR TITLE
KUBOS-465 Making changes to first-project.md according the doc audit issue.

### DIFF
--- a/docs/first-project.md
+++ b/docs/first-project.md
@@ -1,4 +1,4 @@
-# Getting started with Kubos SDK
+# Getting Started With Kubos SDK
 
 This is intended to be a quick guide to creating a new KubOS RT project on top of the Kubos framework.
 
@@ -10,75 +10,48 @@ Create an instance of the Kubos Vagrant box
 
         $ vagrant init kubostech/kubos-dev
 
-This will create a Vagrantfile in your current directory. This Vagrantfile contains information about the configuration of your kubos-dev Vagrant box.
-
-It is strongly recommended that you create your kubos projects in a directory that is shared with your box from your host, rather than a directory that is only available inside your box. If the
-directory is located on your host your projects will be protected in the event your box is ever damaged or destroyed.
-
-To mount a specific directory from your host, open the Vagrantfile that was in the kubos-vagrant directory you clone in the above step and look for the following lines:
-
-        # Share an additional folder to the guest VM. The first argument is
-        # the path on the host to the actual folder. The second argument is
-        # the path on the guest to mount the folder. And the optional third
-        # argument is a set of non-required options.
-        # config.vm.synced_folder "../data", "/vagrant_data"
-
-Uncomment the last line in this block and change the paths to match your host directory and a desired mount point in the box.
-
-Note - The path in the box must be an absolute path. In the kubos-dev vagrant box the home directory is `/home/vagrant`
-
-After a volume is mounted into the box all of the data from the host path will be available at the path specified for the box. In the above example the host path (`../data`) would be exposed at `/vagrant_data` inside of the box.
-This allows you to use the text editor of your choosing to edit the project files from your host machine at the host directory path.
-
-Following the example if you create a kubos project in the box at `/vagrant_data/kubos_project` it would be accessible on your host at the relative path `../data/kubos_project` from your Vagrantfile
-
-For more information on mounting volumes see the following [guide](https://www.vagrantup.com/docs/synced-folders/basic_usage.html)
-
-Start the box
-
-        $ vagrant up
-
 SSH into your box
 
         $ vagrant ssh
 
 At this point you will have a new terminal prompt inside your kubos-dev box.
 
-## Creating your project
+## Creating your Project
 
-The simplest way to create a new KubOS RT project is by using the Kubos CLI. The `kubos init` command takes a project name and creates the project files & folder.
+The simplest way to create a new KubOS RT project is by using the Kubos CLI. The `kubos init` command takes a project name and creates the project files and folders.
 
-**Note:** Inside of the build system there are several reserved words, a project cannot be named any of these words. The most common of these are `test`, `source` and `include`.
+**Note:** Inside of the build system there are several reserved words, which cannot be used as the name of the project. The most common of these are `test`, `source` and `include`.
 
         $ kubos init myproject
 
-The `init` command creates a new directory with the kubos-rt-example included so you can get started right away.
+The `init` command creates a new directory with the [kubos-rt-example](https://github.com/kubostech/kubos-rt-example) included so you can get started right away.
 
+## Cloning a Project
 
 We have also created several different example Kubos projects which can be used as starting points.
 
- - [Example showing basic freertos tasks and csp](https://github.com/kubostech/kubos-rt-example)
- - [Example showing the i2c HAL and sensors](https://github.com/kubostech/kubos-i2c-example)
- - [Example showing the spi HAL and sensors](https://github.com/kubostech/kubos-spi-example)
+ - [Example showing basic FreeRTOS tasks and CSP](https://github.com/kubostech/kubos-rt-example)
+ - [Example showing the I2C HAL and sensors](https://github.com/kubostech/kubos-i2c-example)
+ - [Example showing the SPI HAL and sensors](https://github.com/kubostech/kubos-spi-example)
  - [Example showing the sensor interface](https://github.com/kubostech/kubos-sensor-example)
- - [Example showing csp over uart](https://github.com/kubostech/kubos-csp-example)
+ - [Example showing CSP over UART](https://github.com/kubostech/kubos-csp-example)
  - [Example KubOS Linux project](https://github.com/kubostech/kubos-linux-example)
 
-If you would prefer to use one of our other examples as a starting point all you need to do is run:
+If you would like to use one of our projects, you will need to clone and link the necessary files. For example:
 
         $ git clone https://github.com/kubostech/kubos-spi-example myproject
-
-It is unnecessary to run the `kubos init` command in this case.
-
-If you created your project from a clone there's some additional setup needed to satisfy all of the projects dependencies for Kubos source modules.
-
-Running the following commands will clone a project and link all of the Kubos modules needed to build it:
-
-        $ git clone <url of the project you want>
-        $ cd <project name>
+        $ cd myproject
         $ kubos link --all
 
-## Choosing a target
+**Note:** It is unnecessary to run the `kubos init` command in this case
+
+## Editing the project
+
+Whether you have cloned your Kubos project or created it with the kubos-cli, the default source code entry point is at `{project directory}/source/main.c`. 
+
+There may be additional source files in the `{project directory}/source` directory, depending on the specific project that you are working with. Each of our example applications have a main.c source file as the entry point of the project.
+
+## Choosing a Target
 
 Once you have created a project you will need to select a target. The target defines which hardware your project will run on and how the peripherals are configured.
 
@@ -90,7 +63,9 @@ For this example we will set the msp430f5529 target:
 
         $ kubos target msp430f5529-gcc
 
-## Building and flashing
+For more information on  all of the available Kubos targets and selecting a target see the following **[guide](docs/sdk-cheatsheet.md)**
+
+## Building and Flashing
 
 Now that the target is set you can begin building. This command will build the current project:
 
@@ -100,8 +75,5 @@ You should see the `Build Succeeded` message! You are now ready to load your sof
 
         $ kubos flash
 
-Note - You may need to run this command with `sudo` if you run into a permissions error.
-
-        $ sudo kubos flash
 
 Congratulations! You have just created a basic Kubos project, built it and (hopefully) flashed it onto some hardware.


### PR DESCRIPTION
<summary>first-project.md</summary>

- Capitalize all the section titles except 'your', 'a', and 'and'
- Prerequisites
  - Remove 'create an instance of the kubos vagrant box [...]' since the 'Install the Kubos SDK' link is there and covers that.
  - Remove or greatly shrink the blurb about mounting directories. Again, it's covered by the install doc.
  - 'See the following [guide](link)' Make "guide" bold to make it slightly easier to notice that it's a link.
- Creating your project
  - Change 'project files & folder' to 'project files and folders'
  - 'a project cannot be named any of these words' -> 'which cannot be used as the name of the project'
  - 'kubos-rt-example' - Turn into a hyperlink and link to the kubos-rt-example project
  - Example list: capitalize i2c, spi, csp, and uart
  - Create sub-section 'Cloning a Project'
    - "If you would like to use one of our projects, you will need to clone and link the necessary files. For example:
        $ git clone https://github.com/kubostech/kubos-spi-example myproject
        $ cd myproject
        $ kubos link --all
      
      Note: It is unnecessary to run the `kubos init` command in this case"
- Add a section for editting code - mostly to document that the default source location is {project}/source/main.c
- Choosing a Target - Add link/reference to the SDK Cheatsheet and how it has the list of currently available targets
- Building and Flashing - 'Connect your hardware to your computer' - How? Maybe add a link to a doc that has the instructions for this?
