### PR TITLE
[KUBOS-466] Migrating system directories

### DIFF
--- a/docs/sdk-reference.md
+++ b/docs/sdk-reference.md
@@ -177,12 +177,12 @@ Synonyms: `kubos start`
 Flash a file to the target board.
 
 If the name of the file matches the name of the application, as specified in the module.json file, then the file is assumed to be the application binary and
-will be loaded into /home/usr/bin on the target board.
+will be loaded into /home/system/usr/bin on the target board.
 
 If the name of the file ends in *.itb, the file is a KubOS Linux upgrade package and will be loaded into the upgrade partition of the target board. An internal
 variable will be set so that the upgrade package will be installed during the next reboot of the target board.
 
-All other files are assumed to be non-application files (ex. custom shell scripts) and will be loaded into /home/usr/local/bin.
+All other files are assumed to be non-application files (ex. custom shell scripts) and will be loaded into /home/system/usr/local/bin.
 
 ### Options
 * `file` File to flash.

--- a/targets/target-kubos-linux-isis-gcc/minicom/flash.sh
+++ b/targets/target-kubos-linux-isis-gcc/minicom/flash.sh
@@ -69,7 +69,7 @@ timeout 3600
 send "mkdir -p $2"
 send "cd $2"
 send "rm -f ${name}"
-if ${is_app} = 1 send "rm -f /home/etc/init.d/S*${name}"
+if ${is_app} = 1 send "rm -f /home/system/etc/init.d/S*${name}"
 send "rz -w 8192"
 ! sz -w 8192 ${path}
 if ${is_upgrade} = 1 send "fw_setenv kubos_updatefile ${name}"
@@ -107,7 +107,7 @@ create_init_script() {
 #!/bin/sh
 
 NAME=${app_name}
-PROG=/home/usr/bin/\${NAME}
+PROG=/home/system/usr/bin/\${NAME}
 PID=/var/run/\${NAME}.pid
 
 case "\$1" in
@@ -228,7 +228,7 @@ main() {
   elif [[ "${name}" != "${app_name}" ]]; then
     path="${dest_dir}"
   else
-    path="/home/usr/bin"
+    path="/home/system/usr/bin"
     is_app=1
     if [[ "${run_level}" -gt 99 || "${run_level}" -lt 10 ]]; then
       echo "Run level of ${run_level} outside of range (10-99). Setting to default."
@@ -251,7 +251,7 @@ main() {
     is_run=0
     rm send.tmp
     create_init_script
-    create_send_script ${init_script} /home/etc/init.d
+    create_send_script ${init_script} /home/system/etc/init.d
     send_file
     retval=$?
   fi


### PR DESCRIPTION
Moving /home/{usr,etc,var} directories to be under /home/system/{usr,etc,var}. This keeps us within the Linux standard where everything under the /home directory belongs to a user. A new user 'system' is created in kubostech/kubos-linux-build#28

More docs will likely need to be updated, but are currently modified in atleast one other PR.