### PR TITLE
[KUBOS-469] Standards Doc Updates

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,12 +1,12 @@
 ---
 Language:        Cpp
-# BasedOnStyle:  WebKit
+BasedOnStyle:  Google
 AccessModifierOffset: -4
 AlignAfterOpenBracket: Align
-AlignConsecutiveAssignments: false
-AlignConsecutiveDeclarations: false
-AlignEscapedNewlinesLeft: false
-AlignOperands:   false
+AlignConsecutiveAssignments: true
+AlignConsecutiveDeclarations: true
+AlignEscapedNewlinesLeft: true
+AlignOperands:   true
 AlignTrailingComments: false
 AllowAllParametersOfDeclarationOnNextLine: true
 AllowShortBlocksOnASingleLine: true
@@ -14,29 +14,28 @@ AllowShortCaseLabelsOnASingleLine: false
 AllowShortFunctionsOnASingleLine: None
 AllowShortIfStatementsOnASingleLine: true
 AllowShortLoopsOnASingleLine: true
-AlwaysBreakAfterDefinitionReturnType: None
 AlwaysBreakAfterReturnType: None
 AlwaysBreakBeforeMultilineStrings: false
 AlwaysBreakTemplateDeclarations: false
 BinPackArguments: true
 BinPackParameters: true
 BraceWrapping:   
-  AfterClass:      false
-  AfterControlStatement: false
-  AfterEnum:       false
+  AfterClass:      true
+  AfterControlStatement: true
+  AfterEnum:       true
   AfterFunction:   true
-  AfterNamespace:  false
+  AfterNamespace:  true
   AfterObjCDeclaration: false
-  AfterStruct:     false
-  AfterUnion:      false
-  BeforeCatch:     false
-  BeforeElse:      false
+  AfterStruct:     true
+  AfterUnion:      true
+  BeforeCatch:     true
+  BeforeElse:      true
   IndentBraces:    false
 BreakBeforeBinaryOperators: All
-BreakBeforeBraces: Allman
+BreakBeforeBraces: Custom
 BreakBeforeTernaryOperators: true
 BreakConstructorInitializersBeforeComma: true
-ColumnLimit:     0
+ColumnLimit:     78
 CommentPragmas:  '^ IWYU pragma:'
 ConstructorInitializerAllOnOneLineOrOnePerLine: false
 ConstructorInitializerIndentWidth: 4
@@ -46,44 +45,42 @@ DerivePointerAlignment: false
 DisableFormat:   false
 ExperimentalAutoDetectBinPacking: false
 ForEachMacros:   [ foreach, Q_FOREACH, BOOST_FOREACH ]
+# Include Ordering: system libraries (<stdio.h>), then external folders ("ipc/config.h"), then everything else
 IncludeCategories: 
-  - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
-    Priority:        2
-  - Regex:           '^(<|"(gtest|isl|json)/)'
-    Priority:        3
-  - Regex:           '.*'
+  - Regex:           '^<'
     Priority:        1
-IndentCaseLabels: false
+  - Regex:           '^".*\/'
+    Priority:        2
+  - Regex:           '.*'
+    Priority:        3
+IndentCaseLabels: true
 IndentWidth:     4
-IndentWrappedFunctionNames: false
+IndentWrappedFunctionNames: true
 KeepEmptyLinesAtTheStartOfBlocks: true
 MacroBlockBegin: ''
 MacroBlockEnd:   ''
 MaxEmptyLinesToKeep: 1
-NamespaceIndentation: Inner
-ObjCBlockIndentWidth: 4
-ObjCSpaceAfterProperty: true
-ObjCSpaceBeforeProtocolList: true
+NamespaceIndentation: All
 PenaltyBreakBeforeFirstCallParameter: 19
-PenaltyBreakComment: 300
+PenaltyBreakComment: 0
 PenaltyBreakFirstLessLess: 120
 PenaltyBreakString: 1000
-PenaltyExcessCharacter: 1000000
+PenaltyExcessCharacter: 10
 PenaltyReturnTypeOnItsOwnLine: 60
-PointerAlignment: Middle
+PointerAlignment: Right
 ReflowComments:  true
 SortIncludes:    true
-SpaceAfterCStyleCast: false
+SpaceAfterCStyleCast: true
 SpaceBeforeAssignmentOperators: true
 SpaceBeforeParens: ControlStatements
 SpaceInEmptyParentheses: false
-SpacesBeforeTrailingComments: 1
+SpacesBeforeTrailingComments: 4
 SpacesInAngles:  false
-SpacesInContainerLiterals: true
+SpacesInContainerLiterals: false
 SpacesInCStyleCastParentheses: false
 SpacesInParentheses: false
 SpacesInSquareBrackets: false
-Standard:        Cpp03
+Standard:        Cpp11
 TabWidth:        4
 UseTab:          Never
 ...

--- a/docs/kubos-standards.md
+++ b/docs/kubos-standards.md
@@ -108,22 +108,17 @@ This section covers the styling and standards for the various languages and tool
 
 ## C {#c-standards}
 
-[ClangFormat](https://clang.llvm.org/docs/ClangFormat.html) is a series of tools that can be used to automatically correct any C coding inconsistencies. You can find an example which we've used in the '.clang-format' file in the [Kubos repo](https://github.com/kubostech/kubos/blob/master/.clang-format)
+[ClangFormat](https://clang.llvm.org/docs/ClangFormat.html) is a series of tools that can be used to automatically correct any C coding inconsistencies. 
+A stand-alone tool is available, which can then be used with a variety of IDEs. 
+We have created a '.clang-format' file in the [Kubos repo](https://github.com/kubostech/kubos/blob/master/.clang-format) which can be used to automatically correct C code files to conform with our styling.
+
+- [Clang-format with Eclipse](https://github.com/wangzw/CppStyle)
+- [Clang-format with Atom](https://atom.io/packages/clang-format)
+- [Clang-format with Visual Studio](https://marketplace.visualstudio.com/items?itemName=xaver.clang-format)
+
+
 
 *The following subsections are based on a doc generated 2017-04-18 by Coding Standard Generator version 1.13.*
-
-### Names {#c-names}
-
-- Constants, enumerators, and macros should be all upper case.
-- All other names should be all lower case.
-- Words should be separated by underscore (_).
-
-Use sensible, descriptive names.
-Do not use short cryptic names or names based on internal jokes. It should be easy to type a name without looking up how it is spelt.
-Exception: Scratch variables used for temporary storage or indices are best kept short. A programmer reading such variables should be able to assume that its value is not used outside a few lines of code. Common scratch variables for integers are i, j, k, m, n and for characters c and d.
-
-Use name prefixes for identifiers declared in different modules.
-For example, 'csp\_buffer\_free' indicates that the function belongs to the CSP directory.
 
 ### Indentation and Spacing {#c-spacing}
 
@@ -292,6 +287,19 @@ Do not rely on implicit conversion to bool in conditions.
 
     if (ptr)         // wrong
     if (ptr != NULL) // ok
+
+### Names {#c-names}
+
+- Constants, enumerators, and macros should be all upper case.
+- All other names should be all lower case.
+- Words should be separated by underscore (_).
+
+Use sensible, descriptive names.
+Do not use short cryptic names or names based on internal jokes. It should be easy to type a name without looking up how it is spelt.
+Exception: Scratch variables used for temporary storage or indices are best kept short. A programmer reading such variables should be able to assume that its value is not used outside a few lines of code. Common scratch variables for integers are i, j, k, m, n and for characters c and d.
+
+Use name prefixes for identifiers declared in different modules.
+For example, 'csp\_buffer\_free' indicates that the function belongs to the CSP directory.
 
 ## Python {#python-standards}
 

--- a/docs/kubos-standards.md
+++ b/docs/kubos-standards.md
@@ -1,66 +1,83 @@
 # Kubos Standards
 
-This is a doc to maintain the current naming and coding standards when working with the Kubos project.
+[TOC]
 
-## Them's Fightin' Words
+# Kubos Coding and Documentation Standards {#kubos-standards}
+
+This is a doc to maintain the current naming and coding standards when working with the Kubos products.
+
+# Them's Fightin' Words {#fightin-words}
 
 A few of the more _controversial_ rules:
 
 * Spaces, not tabs
-* No if/for/while statements without brackets (C-specific)
+* No if/for/while statements without brackets
 * All brackets on their own line
 * Use oxford commas
 * Single space after periods and colons
 
-## Product Names
+# Product Names {#product-names}
 
 The general naming scheme is "Kub[OS|os] {component}". Note that there is a space separating the two words.
 
-If the component is an OS, then use the capitalized "OS". If not, then use "os".
+If the component is an operating system, then use the capitalized "OS". If not, then use "os". 
+
+At the moment this means specifically:
+- KubOS RT
+- KubOS Linux 
 
 The component should be capitalized like a normal proper noun. First letter capitalized if the component is
 a word, all letters capitalized if the component is an initialism.
 
+For example:
 - Kubos SDK
 - Kubos CLI
-- KubOS RT
-- KubOS Linux
 - Kubos Portal
 - Kubos Core
 
-## File Naming
+# File Naming {#file-naming}
 
-### Code (\*.c, \*.h, scripts, etc)
+## Code (\*.c, \*.h, scripts, etc) {#code}
 
 - No spaces
 - Use underscores to separate words
 - All lowercase
 
-### Docs (\*.md)
+## Docs (\*.md) {#docs}
 
 - No spaces
 - Use hyphens to separate words
 - All lowercase
 
-### Folders
+## Folders {#folders}
 
 - No spaces
 - Use hyphens to separate words
 - All lowercase
 
-### Special Files
+## Special Files {#special-files}
 
-The contributing, license, and readme files should all be uppercased.
+The CONTRIUBUTING, LICENSE, and README files should all be uppercased.
 
 'Vagrantfile', 'Makefile', 'CMake', and other similar files should all be cased to match industry standards.
 
-## Documentation Standards
+# Documentation Standards {#doc-standards}
 
 While creating clean and maintainable code is a high priority for our organization, writing successful documentation can be considered even more important. Documentation is a vital part of the user experience and, in most cases, will be a major component of a new customer's first impression of us.
 
 Each document should be concise and well-written, and should fill some logical gap missing from the current documentation set.
 
-### Headers
+## Consider Your Audience {#doc-audience}
+
+When writing a new document, consider who the expected reader is. 
+
+For a doc like "Installing the Kubos SDK", we can assume that the reader is a brand new user. 
+Therefore, few assumptions should be made about their current knowledge and, instead, the doc should have a great deal more handholding. 
+This means more explicit explanations, more links to external resources, and more screenshots and example commands.
+
+In contrast, with a doc like "Developing Kubos Modules" we can expect the reader to be a) familiar with our products and b) familiar with development in general. In this case, while handholding is still appreciated, the content can be more brief. Essential components are still fleshed out, but peripheral knowledge can be mentioned by simply linking to a relevant resource.
+
+## Headers {#doc-headers}
 
 Headers should be considered the same as section titles. As a result, they should follow the same capitalization rules as titles. When in doubt, [use this tool](http://titlecapitalization.com/) to check what should be capitalized.
 
@@ -72,45 +89,43 @@ For more information, see this the 'Header Id Attributes' section of this [Doxyg
 
 **Note:** For...reasons...doxygen requires that you have two level one headers for each document in order to display the table of contents and headers correctly. The first header is used as the page title and the second is used as an actual level one header.
 
-### Content
+## Content {#doc-content}
 
-The start of each document should have an overview blurb which describes what information the doc covers.
+The start of each document (and preferrably each high-level section) should have an overview blurb which describes what information the doc covers.
 
 Most of our non-code docs are [Markdown](https://www.stack.nl/~dimitri/doxygen/manual/markdown.html) files. As a result, most standard Markdown formatting features are available. 
 
 Some items to remember:
 
 * Single space after periods and colons 
-* No one likes a giant blob of text
-* Use things like bullet points, bold or italicized text, and images to breakup and highlight your content
-* You can pry the oxford comma from my cold, dead hands
+* All commands which are not in a code block should be encased in backticks (\`command\`), rather than single or double quotes.
+* Use things like bullet points, bold or italicized text, and images to breakup and highlight your content (no one likes a giant blob of text)
+* Oxford commas should always be used
 
-## Coding Standards
+# Coding Standards {#coding-standards}
 
-This section should be updated as coding standards are decided.
+This section covers the styling and standards for the various languages and tools that we use.
 
-### C
+## C {#c-standards}
 
 [ClangFormat](https://clang.llvm.org/docs/ClangFormat.html) is a series of tools that can be used to automatically correct any C coding inconsistencies. You can find an example which we've used in the '.clang-format' file in the [Kubos repo](https://github.com/kubostech/kubos/blob/master/.clang-format)
 
 *The following subsections are based on a doc generated 2017-04-18 by Coding Standard Generator version 1.13.*
 
-#### Entity Naming
+### Names {#c-names}
 
 - Constants, enumerators, and macros should be all upper case.
 - All other names should be all lower case.
 - Words should be separated by underscore (_).
-
-#### Names
 
 Use sensible, descriptive names.
 Do not use short cryptic names or names based on internal jokes. It should be easy to type a name without looking up how it is spelt.
 Exception: Scratch variables used for temporary storage or indices are best kept short. A programmer reading such variables should be able to assume that its value is not used outside a few lines of code. Common scratch variables for integers are i, j, k, m, n and for characters c and d.
 
 Use name prefixes for identifiers declared in different modules.
-For example, "csp\_buffer\_free" indicates that the function belongs to the CSP directory.
+For example, 'csp\_buffer\_free' indicates that the function belongs to the CSP directory.
 
-#### Indentation and Spacing
+### Indentation and Spacing {#c-spacing}
 
 **Do not use tabs. Instead, use 4 spaces.** Kubos developers and contributors use a variety of operating systems and development environments. Using spaces ensures that multiple people can contribute to the same file and all indentions will remain the same width, improving readability and cohesion.
 
@@ -157,23 +172,31 @@ Loop and conditional statements should have a single space preceding the conditi
 Lines should not exceed 78 characters.
 Even if your editor handles long lines, other people may have set up their editors differently. Long lines in the code may also cause problems for other programs and printers.
 
-#### Comments
+### Comments {#c-comments}
 
-//TODO: flesh this out. For instance, 'todo statements should not be left in the code unless absolutely necessary'
+All functions should be fully documented in the header file that they belong to. Use the '/** ... */' comment style so that Doxygen can add the function to the generated API documenation. 
 
-Comments should be written in english
+The function comment block should include:
+- The function name
+- A brief description of the function
+- The name, type, and purpose of all input variables
+- The name, type, and purpose of the returned value/s
 
-Use JavaDoc style comments.
+All code comments should be placed above the line the comment describes, indented identically, as opposed to allowing in-line comments.
 
-The comment styles /// and /** ... */ are used by JavaDoc, Doxygen and some other code documenting tools.
-All comments should be placed above the line the comment describes, indented identically.
-
-Being consistent on placement of comments removes any question on what the comment refers to.
+    /* comment here */
+    call_function(do, stuff) /* instead of here */
+    
+Code comments should cover the 'what' and 'why' of the following code, rather than the 'how'.
+    
 Use #ifdef instead of /* ... */ to comment out blocks of code.
+The code that is commented out may already contain comments which then terminate the block comment and causes lots of compile errors or other harder to find errors. 
 
-The code that is commented out may already contain comments which then terminate the block comment and causes lots of compile errors or other harder to find errors.
+**However**, code should not be left permanently commented out; "#ifdef 0" is fine when creating and testing code, but has no place in the final product. Make sure to remove all dead code before merging changes into the master branch.
 
-#### Files
+**Do not leave comments like 'TODO' or 'FIX ME' in your final code changes unless absolutely necessary.** Just do whatever it is that you're trying to procrastinate on. If you must leave a to-do, THERE BETTER BE A STORY FOR IT IN JIRA AND IT BETTER BE AT THE TOP OF THE BACKLOG. "Oh, I'll create a story for it later". NO, YOU WON'T. DO IT NOW.
+
+### Files {#c-files}
 
 Each file must start with a copyright notice.
 
@@ -201,7 +224,7 @@ Put all #define statements immediately after any #include statements.
 
 Put all function prototypes after any #define statements.
 
-#### Declarations
+### Declarations {#c-declarations}
 
 Provide names of parameters in function declarations.
 Parameter names are useful to document what the parameter is used for.
@@ -218,14 +241,48 @@ Use a typedef to define a pointer to a function. Pointers to functions have a st
     trig_func my_func = sin;
     void call_func(trig_func callback);
     trig_func func_table[10];
+    
+If not previously defined in a header file, declare variables as close to the first use as is useful. This is opposed to the old C requirement where all variables in a function needed to be declared before all instruction lines.
 
-#### Statements
+    int doing_stuff(int parameter)
+    {
+    
+        /* declaring 'ret' here since it's needed for both cases */
+        int ret = ALL_OK;
+    
+        if (condition)
+        {
+            /* declaring 'val' here, since it's only used in this one case */
+            int val = doing_things();
+            ret = doing_things_with_val(val);
+        }
+        else
+        {
+            ret = ERROR_CODE;
+        }
+        
+        return ret;
+    }
+
+### Statements {#c-statements}
 
 Never use gotos.
 
 All switch statements should have a `default` label. Even if there is no action for the default label, it should be included to show that the programmer has considered values not covered by case labels. It is normally useful to place an error message in the default label in this case.
 
-#### Other Typographical Issues
+### Return Values {#c-return-values}
+
+In most cases, it is preferable to return an error code, rather than a value. If an output value is desired, a pointer to the desired storage area should be added to the function's arguments. This allows us to be consistent in our declarations.
+
+    int length;
+    int ret;
+    
+    /* Don't do this */
+    length = get_length(input);
+    /* Do this instead */
+    ret = get_length(input, length);
+
+### Other Typographical Issues {#c-other}
 
 Avoid macros; most macros can be replaced by constants, enumerations or inline functions. Using macros can lead to decreased readability and increased chance of bugs.
 
@@ -236,14 +293,19 @@ Do not rely on implicit conversion to bool in conditions.
     if (ptr)         // wrong
     if (ptr != NULL) // ok
 
-### Python
+## Python {#python-standards}
+
+[Pylint](https://pylint.readthedocs.io/en/latest/) is a great tool which can be used to check the style and validity of your python files.
+It has support for a variety of [editors and IDEs](https://pylint.readthedocs.io/en/latest/user_guide/ide-integration.html).
+
+Refer to [Python's Python Style Guide](https://www.python.org/dev/peps/pep-0008/) for our preferred Python styling.
 
 
-### Working with External Projects
+## Working with External Projects {#external-projects}
 
 Some of the Kubos code uses or extends external projects. In this case where you are adding a new file, use the Kubos standards. If you are modifying an existing file, try to match the formatting of the surrounding code. 
 
-#### Linux Kernel
+### Linux Kernel {#linux-kernel}
 
 [Linux kernel coding style](https://01.org/linuxgraphics/gfx-docs/drm/process/coding-style.html)
 
@@ -252,7 +314,7 @@ Notably:
 - 8 space indentation
 - Torvalds disagrees with us on basically everything
 
-#### U-Boot
+### U-Boot {#uboot}
 
 [U-Boot coding style](http://www.denx.de/wiki/U-Boot/CodingStyle)
 
@@ -262,12 +324,12 @@ Notably:
 - Tabs, not spaces
 - No C++ style comments (use /* */, not //)
 
-### Other Languages
+## Other Languages {#other-languages}
 
-Bash: Refer to [Google's style guide](https://google.github.io/styleguide/shell.xml). **Exception:** Use 4 spaces, since that's what we do in all of our other languages.
+Bash - Refer to [Google's style guide](https://google.github.io/styleguide/shell.xml). **Exception:** Use 4 spaces, since that's what we do in all of our other languages.
 
 [KConfig](https://www.kernel.org/doc/Documentation/kbuild/kconfig-language.txt)
 
-## CONSISTENCY
+# CONSISTENCY {#consistency}
 
 BE CONSISTENT. I DON'T CARE IF YOU IGNORE EVERY OTHER RULE IN THIS DOC (okay, I do care, but I'm trying to make a point), JUST MAKE SURE THAT WHATEVER YOU DO, IT LOOKS AND SMELLS THE SAME AS EVERYTHING ELSE YOU DO AND/OR EVERYTHING ELSE AROUND IT.

--- a/docs/kubos-standards.md
+++ b/docs/kubos-standards.md
@@ -6,16 +6,6 @@
 
 This is a doc to maintain the current naming and coding standards when working with the Kubos products.
 
-# Them's Fightin' Words {#fightin-words}
-
-A few of the more _controversial_ rules:
-
-* Spaces, not tabs
-* No if/for/while statements without brackets
-* All brackets on their own line
-* Use oxford commas
-* Single space after periods and colons
-
 # Product Names {#product-names}
 
 The general naming scheme is "Kub[OS|os] {component}". Note that there is a space separating the two words.
@@ -60,6 +50,16 @@ For example:
 The CONTRIUBUTING, LICENSE, and README files should all be uppercased.
 
 'Vagrantfile', 'Makefile', 'CMake', and other similar files should all be cased to match industry standards.
+
+# Them's Fightin' Words {#fightin-words}
+
+A few of the more _controversial_ rules:
+
+* Spaces, not tabs
+* No if/for/while statements without brackets
+* All brackets on their own line
+* Use oxford commas
+* Single space after periods and colons
 
 # Documentation Standards {#doc-standards}
 
@@ -116,9 +116,92 @@ We have created a '.clang-format' file in the [Kubos repo](https://github.com/ku
 - [Clang-format with Atom](https://atom.io/packages/clang-format)
 - [Clang-format with Visual Studio](https://marketplace.visualstudio.com/items?itemName=xaver.clang-format)
 
-
-
 *The following subsections are based on a doc generated 2017-04-18 by Coding Standard Generator version 1.13.*
+
+### Files {#c-files}
+
+Each file must start with a copyright notice.
+
+Header files must have a `#pragma once` statement. This causes the file to be included only once. 
+If for some reason you encounter a scenario where the pragma statements are not supported, use include guards instead.
+The name used in the include guard should be the same name as the file (excluding the extension) followed by the suffix "_H".
+
+Example:
+
+    #pragma once
+    
+    OR
+
+    #ifndef FILE_H
+    #define FILE_H
+    ...
+    #endif
+    
+System header files should be included with <> and project headers with "".
+
+Put all #include directives at the top of files. Having all #include directives in one place makes it easy to find them.
+Do not use absolute directory names in #include directives.
+
+Put all #define statements immediately after any #include statements.
+
+Put all function prototypes after any #define statements.
+
+
+### Comments {#c-comments}
+
+All functions should be fully documented in the header file that they belong to. Use the '/** ... */' comment style so that Doxygen can add the function to the generated API documenation. 
+
+The function comment block should include:
+- A brief description of the function
+- The name, type, and purpose of all input variables
+- The name, type, and purpose of the returned value/s
+
+For example:
+
+    /**
+     * Read data over i2c bus from specified address
+     *
+     * In order to ensure safe i2c sharing, this function is semaphore locked.
+     * There is one semaphore per bus. This function will block indefinitely
+     * while waiting for the semaphore.
+     *
+     * @param i2c i2c bus to read from
+     * @param addr address of target i2c device
+     * @param ptr pointer to data buffer
+     * @param len length of data to read
+     * @return int I2C_OK on success, I2C_ERROR on error
+     */
+    KI2CStatus k_i2c_read(KI2CNum i2c, uint16_t addr, uint8_t *ptr, int len);
+
+For large and/or complex functions, it is helpful to also include the function comment block just above where the function is actually implemented.
+This way the developer can quickly review what the function is and how it's supposed to work. The regular '/* ... */' comment styling is acceptable in this case.
+
+All code comments should be placed above the line the comment describes, indented identically, as opposed to allowing in-line comments.
+
+    /* comment here */
+    call_function(do, stuff) /* instead of here */
+    
+Code comments should cover the 'what' and 'why' of the following code, rather than the 'how'.
+    
+Use #ifdef instead of /* ... */ to comment out blocks of code.
+The code that is commented out may already contain comments which then terminate the block comment and causes lots of compile errors or other harder to find errors. 
+
+**However**, code should not be left permanently commented out; "#ifdef 0" is fine when creating and testing code, but has no place in the final product. Make sure to remove all dead code before merging changes into the master branch.
+
+**Do not leave comments like 'TODO' or 'FIX ME' in your final code changes unless absolutely necessary.** Just do whatever it is that you're trying to procrastinate on. If you must leave a to-do, THERE BETTER BE A STORY FOR IT IN JIRA AND IT BETTER BE AT THE TOP OF THE BACKLOG. "Oh, I'll create a story for it later". NO, YOU WON'T. DO IT NOW.
+
+### Names {#c-names}
+
+- Constants, enumerators, and macros should be all upper case.
+- All other names should be all lower case.
+- Words should be separated by underscore (_).
+
+Use sensible, descriptive names.
+Do not use short cryptic names or names based on internal jokes. It should be easy to type a name without looking up how it is spelt.
+Exception: Scratch variables used for temporary storage or indices are best kept short. A programmer reading such variables should be able to assume that its value is not used outside a few lines of code. Common scratch variables for integers are i, j, k, m, n and for characters c and d.
+
+Use name prefixes for identifiers declared in different modules.
+For example, 'csp\_buffer\_free' indicates that the function belongs to the CSP directory.
 
 ### Indentation and Spacing {#c-spacing}
 
@@ -166,58 +249,6 @@ Loop and conditional statements should have a single space preceding the conditi
 
 Lines should not exceed 78 characters.
 Even if your editor handles long lines, other people may have set up their editors differently. Long lines in the code may also cause problems for other programs and printers.
-
-### Comments {#c-comments}
-
-All functions should be fully documented in the header file that they belong to. Use the '/** ... */' comment style so that Doxygen can add the function to the generated API documenation. 
-
-The function comment block should include:
-- The function name
-- A brief description of the function
-- The name, type, and purpose of all input variables
-- The name, type, and purpose of the returned value/s
-
-All code comments should be placed above the line the comment describes, indented identically, as opposed to allowing in-line comments.
-
-    /* comment here */
-    call_function(do, stuff) /* instead of here */
-    
-Code comments should cover the 'what' and 'why' of the following code, rather than the 'how'.
-    
-Use #ifdef instead of /* ... */ to comment out blocks of code.
-The code that is commented out may already contain comments which then terminate the block comment and causes lots of compile errors or other harder to find errors. 
-
-**However**, code should not be left permanently commented out; "#ifdef 0" is fine when creating and testing code, but has no place in the final product. Make sure to remove all dead code before merging changes into the master branch.
-
-**Do not leave comments like 'TODO' or 'FIX ME' in your final code changes unless absolutely necessary.** Just do whatever it is that you're trying to procrastinate on. If you must leave a to-do, THERE BETTER BE A STORY FOR IT IN JIRA AND IT BETTER BE AT THE TOP OF THE BACKLOG. "Oh, I'll create a story for it later". NO, YOU WON'T. DO IT NOW.
-
-### Files {#c-files}
-
-Each file must start with a copyright notice.
-
-Header files must have a `#pragma once` statement. This causes the file to be included only once. 
-If for some reason you encounter a scenario where the pragma statements are not supported, use include guards instead.
-The name used in the include guard should be the same name as the file (excluding the extension) followed by the suffix "_H".
-
-Example:
-
-    #pragma once
-    
-    OR
-
-    #ifndef FILE_H
-    #define FILE_H
-    ...
-    #endif
-    
-System header files should be included with <> and project headers with "".
-
-Put all #include directives at the top of files. Having all #include directives in one place makes it easy to find them.
-Do not use absolute directory names in #include directives.
-
-Put all #define statements immediately after any #include statements.
-
-Put all function prototypes after any #define statements.
 
 ### Declarations {#c-declarations}
 
@@ -288,18 +319,6 @@ Do not rely on implicit conversion to bool in conditions.
     if (ptr)         // wrong
     if (ptr != NULL) // ok
 
-### Names {#c-names}
-
-- Constants, enumerators, and macros should be all upper case.
-- All other names should be all lower case.
-- Words should be separated by underscore (_).
-
-Use sensible, descriptive names.
-Do not use short cryptic names or names based on internal jokes. It should be easy to type a name without looking up how it is spelt.
-Exception: Scratch variables used for temporary storage or indices are best kept short. A programmer reading such variables should be able to assume that its value is not used outside a few lines of code. Common scratch variables for integers are i, j, k, m, n and for characters c and d.
-
-Use name prefixes for identifiers declared in different modules.
-For example, 'csp\_buffer\_free' indicates that the function belongs to the CSP directory.
 
 ## Python {#python-standards}
 

--- a/docs/kubos-standards.md
+++ b/docs/kubos-standards.md
@@ -8,16 +8,17 @@ A few of the more _controversial_ rules:
 
 * Spaces, not tabs
 * No if/for/while statements without brackets (C-specific)
+* All brackets on their own line
 * Use oxford commas
 * Single space after periods and colons
 
 ## Product Names
 
-The general naming scheme is "Kub[OS|os] {component}".  Note that there is a space separating the two words.
+The general naming scheme is "Kub[OS|os] {component}". Note that there is a space separating the two words.
 
-If the component is an OS, then use the capitalized "OS".  If not, then use "os".
+If the component is an OS, then use the capitalized "OS". If not, then use "os".
 
-The component should be capitalized like a normal proper noun.  First letter capitalized if the component is
+The component should be capitalized like a normal proper noun. First letter capitalized if the component is
 a word, all letters capitalized if the component is an initialism.
 
 - Kubos SDK
@@ -90,17 +91,182 @@ This section should be updated as coding standards are decided.
 
 ### C
 
-[ClangFormat](https://clang.llvm.org/docs/ClangFormat.html) is a series of tools that can be used to automatically correct any C coding inconsistencies. You can find an example which we've used in the '.clang-format' file in the [Kubos repo](https://github.com/kubostech/kubos/blob/master/.clang-format
+[ClangFormat](https://clang.llvm.org/docs/ClangFormat.html) is a series of tools that can be used to automatically correct any C coding inconsistencies. You can find an example which we've used in the '.clang-format' file in the [Kubos repo](https://github.com/kubostech/kubos/blob/master/.clang-format)
 
-- Four spaces, not tabs (for consistency between OS's)
-- All brackets should be on their own line
-- All `if`, `while`, and `for` statements should use brackets
+*The following subsections are based on a doc generated 2017-04-18 by Coding Standard Generator version 1.13.*
 
+#### Entity Naming
 
+- Constants, enumerators, and macros should be all upper case.
+- All other names should be all lower case.
+- Words should be separated by underscore (_).
+
+#### Names
+
+Use sensible, descriptive names.
+Do not use short cryptic names or names based on internal jokes. It should be easy to type a name without looking up how it is spelt.
+Exception: Scratch variables used for temporary storage or indices are best kept short. A programmer reading such variables should be able to assume that its value is not used outside a few lines of code. Common scratch variables for integers are i, j, k, m, n and for characters c and d.
+
+Use name prefixes for identifiers declared in different modules.
+For example, "csp\_buffer\_free" indicates that the function belongs to the CSP directory.
+
+#### Indentation and Spacing
+
+**Do not use tabs. Instead, use 4 spaces.** Kubos developers and contributors use a variety of operating systems and development environments. Using spaces ensures that multiple people can contribute to the same file and all indentions will remain the same width, improving readability and cohesion.
+
+Braces should follow "Exdented Style".
+
+The Exdented Bracing Style means that the curly brace pair are lined up with the surrounding statement. Statements and declarations between the braces are indented relative to the braces.
+Braces should be indented 4 columns to the right of the starting position of the enclosing statement or declaration.
+
+Example:
+
+    void f(int a)
+    {
+        int i;
+        if (a > 0)
+        {
+            i = a;
+        }
+        else
+        {
+            i = a;
+        }
+    }
+    
+Loop and conditional statements (`if`, `for`, `while`) should always have brace enclosed sub-statements. The code looks more consistent if all conditional and loop statements have braces. Even if there is only a single statement after the condition or loop statement today, there might be a need for more code in the future.
+
+Braces without any contents may be placed on the same line.
+
+    while (...) {//do nothing};
+
+Each statement should be placed on a line on its own. There is no need to make code compact. Putting several statements on the same line only makes the code cryptic to read.
+
+Declare each variable in a separate declaration.
+This makes it easier to see all variables. It also avoids the problem of knowing which variables are pointers.
+int* p, i;
+It is easy to forget that the star belongs to the declared name, not the type, and look at this and say that the type is "pointer to int" and both p and i are declared to this type.
+
+All binary arithmetic, bitwise and assignment operators and the ternary conditional operator (?:) should be surrounded by spaces; the comma operator should be followed by a space but not preceded. **Exception:** No spaces around pre/postfix increment and decrement operators ('++', '--').
+
+Loop and conditional statements should have a single space preceding the condition in parenthesis.
+
+    if (condition) /* correct */
+    if(condition)  /* wrong */
+
+Lines should not exceed 78 characters.
+Even if your editor handles long lines, other people may have set up their editors differently. Long lines in the code may also cause problems for other programs and printers.
+
+#### Comments
+
+//TODO: flesh this out. For instance, 'todo statements should not be left in the code unless absolutely necessary'
+
+Comments should be written in english
+
+Use JavaDoc style comments.
+
+The comment styles /// and /** ... */ are used by JavaDoc, Doxygen and some other code documenting tools.
+All comments should be placed above the line the comment describes, indented identically.
+
+Being consistent on placement of comments removes any question on what the comment refers to.
+Use #ifdef instead of /* ... */ to comment out blocks of code.
+
+The code that is commented out may already contain comments which then terminate the block comment and causes lots of compile errors or other harder to find errors.
+
+#### Files
+
+Each file must start with a copyright notice.
+
+Header files must have a `#pragma once` statement. This causes the file to be included only once. 
+If for some reason you encounter a scenario where the pragma statements are not supported, use include guards instead.
+The name used in the include guard should be the same name as the file (excluding the extension) followed by the suffix "_H".
+
+Example:
+
+    #pragma once
+    
+    OR
+
+    #ifndef FILE_H
+    #define FILE_H
+    ...
+    #endif
+    
+System header files should be included with <> and project headers with "".
+
+Put all #include directives at the top of files. Having all #include directives in one place makes it easy to find them.
+Do not use absolute directory names in #include directives.
+
+Put all #define statements immediately after any #include statements.
+
+Put all function prototypes after any #define statements.
+
+#### Declarations
+
+Provide names of parameters in function declarations.
+Parameter names are useful to document what the parameter is used for.
+The parameter names should be the same in all declarations and definitions of the function.
+
+Always provide the return type explicitly.
+
+Use a typedef to define a pointer to a function. Pointers to functions have a strange syntax. The code becomes much clearer if you use a typedef for the pointer to function type. This typedef name can then be used to declare variables etc.
+
+    double sin(double arg);
+    typedef double (*trig_func)(double arg);
+    
+    /* Usage examples */
+    trig_func my_func = sin;
+    void call_func(trig_func callback);
+    trig_func func_table[10];
+
+#### Statements
+
+Never use gotos.
+
+All switch statements should have a `default` label. Even if there is no action for the default label, it should be included to show that the programmer has considered values not covered by case labels. It is normally useful to place an error message in the default label in this case.
+
+#### Other Typographical Issues
+
+Avoid macros; most macros can be replaced by constants, enumerations or inline functions. Using macros can lead to decreased readability and increased chance of bugs.
+
+Do not use literal numbers other than 0 and 1. Use constants instead of literal numbers to make the code consistent and easy to maintain. The name of the constant is also used to document the purpose of the number.
+
+Do not rely on implicit conversion to bool in conditions.
+
+    if (ptr)         // wrong
+    if (ptr != NULL) // ok
 
 ### Python
 
-### Bash
+
+### Working with External Projects
+
+Some of the Kubos code uses or extends external projects. In this case where you are adding a new file, use the Kubos standards. If you are modifying an existing file, try to match the formatting of the surrounding code. 
+
+#### Linux Kernel
+
+[Linux kernel coding style](https://01.org/linuxgraphics/gfx-docs/drm/process/coding-style.html)
+
+Notably:
+
+- 8 space indentation
+- Torvalds disagrees with us on basically everything
+
+#### U-Boot
+
+[U-Boot coding style](http://www.denx.de/wiki/U-Boot/CodingStyle)
+
+Notably:
+
+- Mostly follows the Linux coding style
+- Tabs, not spaces
+- No C++ style comments (use /* */, not //)
+
+### Other Languages
+
+Bash: Refer to [Google's style guide](https://google.github.io/styleguide/shell.xml). **Exception:** Use 4 spaces, since that's what we do in all of our other languages.
+
+[KConfig](https://www.kernel.org/doc/Documentation/kbuild/kconfig-language.txt)
 
 ## CONSISTENCY
 

--- a/docs/kubos-standards.md
+++ b/docs/kubos-standards.md
@@ -303,11 +303,20 @@ For example, 'csp\_buffer\_free' indicates that the function belongs to the CSP 
 
 ## Python {#python-standards}
 
-[Pylint](https://pylint.readthedocs.io/en/latest/) is a great tool which can be used to check the style and validity of your python files.
+[Python's PEP8 Style Guide](https://www.python.org/dev/peps/pep-0008/) is our preferred Python styling.
+
+[PyLint](https://pylint.readthedocs.io/en/latest/) is a great tool which can be used to check the style and validity of your python files.
 It has support for a variety of [editors and IDEs](https://pylint.readthedocs.io/en/latest/user_guide/ide-integration.html).
 
-Refer to [Python's Python Style Guide](https://www.python.org/dev/peps/pep-0008/) for our preferred Python styling.
+* [PyLint via PyDev for Eclipse](http://www.pydev.org/manual_adv_pylint.html)
+* [PyLint for Atom](https://atom.io/packages/linter-pylint)
+* [PyLint for Visual Studio](https://www.mantidproject.org/How_to_run_Pylint)
 
+[Autopep8](https://pypi.python.org/pypi/autopep8) can be used to automatically format your code to conform with the Python PEP8 standard.
+
+* [Autopep8 via PyDev for Eclipse](https://marketplace.eclipse.org/content/pydev-python-ide-eclipse)
+* [Autopep8 for Atom](https://atom.io/packages/python-autopep8)
+* [Autopep8 for Visual Studio](https://marketplace.visualstudio.com/items?itemName=himanoa.Python-autopep8)
 
 ## Working with External Projects {#external-projects}
 

--- a/docs/kubos-standards.md
+++ b/docs/kubos-standards.md
@@ -100,7 +100,7 @@ Some items to remember:
 * Single space after periods and colons 
 * All commands which are not in a code block should be encased in backticks (\`command\`), rather than single or double quotes.
 * Use things like bullet points, bold or italicized text, and images to breakup and highlight your content (no one likes a giant blob of text)
-* Oxford commas should always be used
+* Oxford commas should **always** be used
 
 # Coding Standards {#coding-standards}
 
@@ -151,11 +151,11 @@ Example:
     
 Loop and conditional statements (`if`, `for`, `while`) should always have brace enclosed sub-statements. The code looks more consistent if all conditional and loop statements have braces. Even if there is only a single statement after the condition or loop statement today, there might be a need for more code in the future.
 
-Braces without any contents may be placed on the same line.
+Braces without any content may be placed on the same line.
 
     while (...) {//do nothing};
 
-Each statement should be placed on a line on its own. There is no need to make code compact. Putting several statements on the same line only makes the code cryptic to read.
+Each statement should be placed on its own line. There is no need to make code compact. Putting several statements on the same line only makes the code cryptic to read.
 
 Declare each variable in a separate declaration.
 This makes it easier to see all variables. It also avoids the problem of knowing which variables are pointers.

--- a/docs/kubos-standards.md
+++ b/docs/kubos-standards.md
@@ -2,7 +2,16 @@
 
 This is a doc to maintain the current naming and coding standards when working with the Kubos project.
 
-##Product Names
+## Them's Fightin' Words
+
+A few of the more _controversial_ rules:
+
+* Spaces, not tabs
+* No if/for/while statements without brackets (C-specific)
+* Use oxford commas
+* Single space after periods and colons
+
+## Product Names
 
 The general naming scheme is "Kub[OS|os] {component}".  Note that there is a space separating the two words.
 
@@ -18,38 +27,81 @@ a word, all letters capitalized if the component is an initialism.
 - Kubos Portal
 - Kubos Core
 
-##File Naming
+## File Naming
 
-###Code (\*.c, \*.h, scripts, etc)
+### Code (\*.c, \*.h, scripts, etc)
 
 - No spaces
 - Use underscores to separate words
 - All lowercase
 
-###Docs (\*.md)
+### Docs (\*.md)
 
 - No spaces
 - Use hyphens to separate words
 - All lowercase
 
-###Folders
+### Folders
 
 - No spaces
 - Use hyphens to separate words
 - All lowercase
 
-###Special Files
+### Special Files
 
 The contributing, license, and readme files should all be uppercased.
 
 'Vagrantfile', 'Makefile', 'CMake', and other similar files should all be cased to match industry standards.
 
-##Coding Standards
+## Documentation Standards
+
+While creating clean and maintainable code is a high priority for our organization, writing successful documentation can be considered even more important. Documentation is a vital part of the user experience and, in most cases, will be a major component of a new customer's first impression of us.
+
+Each document should be concise and well-written, and should fill some logical gap missing from the current documentation set.
+
+### Headers
+
+Headers should be considered the same as section titles. As a result, they should follow the same capitalization rules as titles. When in doubt, [use this tool](http://titlecapitalization.com/) to check what should be capitalized.
+
+If you would like to include a table of contents, or would like to be able to link to a specific section, each header should also have a section label.
+
+To include a table of contents, add "[TOC]" after your first header.
+
+For more information, see this the 'Header Id Attributes' section of this [Doxygen doc](https://www.stack.nl/~dimitri/doxygen/manual/markdown.html#md_links).
+
+**Note:** For...reasons...doxygen requires that you have two level one headers for each document in order to display the table of contents and headers correctly. The first header is used as the page title and the second is used as an actual level one header.
+
+### Content
+
+The start of each document should have an overview blurb which describes what information the doc covers.
+
+Most of our non-code docs are [Markdown](https://www.stack.nl/~dimitri/doxygen/manual/markdown.html) files. As a result, most standard Markdown formatting features are available. 
+
+Some items to remember:
+
+* Single space after periods and colons 
+* No one likes a giant blob of text
+* Use things like bullet points, bold or italicized text, and images to breakup and highlight your content
+* You can pry the oxford comma from my cold, dead hands
+
+## Coding Standards
 
 This section should be updated as coding standards are decided.
 
-###C
+### C
+
+[ClangFormat](https://clang.llvm.org/docs/ClangFormat.html) is a series of tools that can be used to automatically correct any C coding inconsistencies. You can find an example which we've used in the '.clang-format' file in the [Kubos repo](https://github.com/kubostech/kubos/blob/master/.clang-format
 
 - Four spaces, not tabs (for consistency between OS's)
 - All brackets should be on their own line
-- All `if` statements should use brackets
+- All `if`, `while`, and `for` statements should use brackets
+
+
+
+### Python
+
+### Bash
+
+## CONSISTENCY
+
+BE CONSISTENT. I DON'T CARE IF YOU IGNORE EVERY OTHER RULE IN THIS DOC (okay, I do care, but I'm trying to make a point), JUST MAKE SURE THAT WHATEVER YOU DO, IT LOOKS AND SMELLS THE SAME AS EVERYTHING ELSE YOU DO AND/OR EVERYTHING ELSE AROUND IT.


### PR DESCRIPTION
Updating our standards doc to contain actual, fleshed out standards.

Also updated the .clang-format file to match these new standards.

Questions:
- C
  - Implicit conversion to bool in conditions? ("if (ret)" vs "if (ret != NULL)")
  - Each variable in own declaration?
  - Returning: only allow return codes, or allow return values as well?
  - Comments: only allow C style (/* */), or allow C++ style, too (//)

@kyleparrott, @plauche, @davesims, or really, anyone who actually knows and uses Python. I just put a link to the pep8 standard. I don't if we want to go into any more detail than that...