### PR TITLE
[KUBOS-490] Fixing RT Example on MSP430

### DIFF
--- a/freertos/config-msp430f5529/FreeRTOSConfig.h
+++ b/freertos/config-msp430f5529/FreeRTOSConfig.h
@@ -90,7 +90,7 @@
 #define configCPU_CLOCK_HZ			( ( unsigned long ) 7995392 ) /* Clock setup from main.c in the demo application. */
 #define configTICK_RATE_HZ			( ( TickType_t ) 1000 )
 #define configMAX_PRIORITIES		( 4 )
-#define configMINIMAL_STACK_SIZE	( ( unsigned short ) 200 )
+#define configMINIMAL_STACK_SIZE	( ( unsigned short ) 100 ) // NOTE: this is measured in words (not bytes!)
 #define configTOTAL_HEAP_SIZE		( ( size_t ) ( 1024 ) )
 #define configMAX_TASK_NAME_LEN		( 8 )
 #define configUSE_TRACE_FACILITY	1

--- a/targets/target-msp430f5529-gcc/CMake/toolchain.cmake
+++ b/targets/target-msp430f5529-gcc/CMake/toolchain.cmake
@@ -1,4 +1,4 @@
-IF(TARGET_MSP430_GCC_TOOLCHAIN_INCLUDED)
+if(TARGET_MSP430_GCC_TOOLCHAIN_INCLUDED)
     return()
 endif()
 set(TARGET_MSP430_GCC_TOOLCHAIN_INCLUDED 1)
@@ -6,10 +6,21 @@ set(TARGET_MSP430_GCC_TOOLCHAIN_INCLUDED 1)
 set(_CPU_COMPILATION_OPTIONS "-mmcu=msp430f5529")
 set(_CPU_DEFINES "")
 
+set(MEMORY_X "${CMAKE_CURRENT_LIST_DIR}/../ld/memory.x")
+
+# Users can force demarcation of the 2K usb ram segment in the linker script
+# at the 0x1c00 address that is normally claimed by the entire 10K "ram" segment
+# Example in a Kubos application's config.json (at the project root):
+#
+# { "kubos-build": { "msp430-usbram": true } }
+
+if(YOTTA_CFG_KUBOS_BUILD_MSP430_USBRAM)
+    set(MEMORY_X "${CMAKE_CURRENT_LIST_DIR}/../ld/memory_usbram.x")
+endif()
 
 set(CMAKE_C_FLAGS_INIT             "${CMAKE_C_FLAGS_INIT} ${_CPU_COMPILATION_OPTIONS} ${_CPU_DEFINES}")
 set(CMAKE_ASM_FLAGS_INIT           "${CMAKE_ASM_FLAGS_INIT} ${_CPU_COMPILATION_OPTIONS} ${_CPU_DEFINES}")
 set(CMAKE_CXX_FLAGS_INIT           "${CMAKE_CXX_FLAGS_INIT} ${_CPU_COMPILATION_OPTIONS} ${_CPU_DEFINES}")
 set(CMAKE_MODULE_LINKER_FLAGS_INIT "${CMAKE_MODULE_LINKER_FLAGS_INIT} ${_CPU_COMPILATION_OPTIONS}")
 set(CMAKE_C_LINK_FLAGS             "${CMAKE_C_LINK_FLAGS} ${_CPU_COMPILATION_OPTIONS}")
-set(CMAKE_EXE_LINKER_FLAGS_INIT    "${CMAKE_EXE_LINKER_FLAGS_INIT} -T\"${CMAKE_CURRENT_LIST_DIR}/../ld/memory.x\" -T\"${CMAKE_CURRENT_LIST_DIR}/../ld/periph.x\" -T\"${CMAKE_CURRENT_LIST_DIR}/../ld/msp430.x\"")
+set(CMAKE_EXE_LINKER_FLAGS_INIT    "${CMAKE_EXE_LINKER_FLAGS_INIT} -T\"${MEMORY_X}\" -T\"${CMAKE_CURRENT_LIST_DIR}/../ld/periph.x\" -T\"${CMAKE_CURRENT_LIST_DIR}/../ld/msp430.x\"")

--- a/targets/target-msp430f5529-gcc/ld/memory.x
+++ b/targets/target-msp430f5529-gcc/ld/memory.x
@@ -8,21 +8,18 @@ MEMORY {
   infoc            : ORIGIN = 0x1880, LENGTH = 0x0080 /* END=0x1900, size 128 */
   infob            : ORIGIN = 0x1900, LENGTH = 0x0080 /* END=0x1980, size 128 */
   infoa            : ORIGIN = 0x1980, LENGTH = 0x0080 /* END=0x1a00, size 128 */
-  usbram (wx)      : ORIGIN = 0x1c00, LENGTH = 0x0800 /* END=0x2400, size 2K */
-  ram (wx)         : ORIGIN = 0x2400, LENGTH = 0x2000 /* END=0x4400, size 8K */
+  ram (wx)         : ORIGIN = 0x1c00, LENGTH = 0x2800 /* END=0x4400, size 10K */
   rom (rx)         : ORIGIN = 0x4400, LENGTH = 0xbb80 /* END=0xff80, size 48000 */
   vectors          : ORIGIN = 0xff80, LENGTH = 0x0080 /* END=0x10000, size 128 as 64 2-byte segments */
   far_rom          : ORIGIN = 0x00010000, LENGTH = 0x00014400 /* END=0x00024400, size 81K */
   /* Remaining banks are absent */
   ram2 (wx)        : ORIGIN = 0x0000, LENGTH = 0x0000
   ram_mirror (wx)  : ORIGIN = 0x0000, LENGTH = 0x0000
-  signature        : ORIGIN = 0x0000, LENGTH = 0x0000
+  usbram (wx)      : ORIGIN = 0x0000, LENGTH = 0x0000
 }
 REGION_ALIAS("REGION_TEXT", rom);
 REGION_ALIAS("REGION_DATA", ram);
-REGION_ALIAS("REGION_FAR_ROM", far_rom); /* Legacy name, no longer used */
-REGION_ALIAS("REGION_FAR_TEXT", far_rom);
-REGION_ALIAS("REGION_FAR_DATA", ram2);
+REGION_ALIAS("REGION_FAR_ROM", far_rom);
 PROVIDE (__info_segment_size = 0x80);
 PROVIDE (__infod = 0x1800);
 PROVIDE (__infoc = 0x1880);

--- a/targets/target-msp430f5529-gcc/ld/memory_usbram.x
+++ b/targets/target-msp430f5529-gcc/ld/memory_usbram.x
@@ -1,0 +1,30 @@
+MEMORY {
+  sfr              : ORIGIN = 0x0000, LENGTH = 0x0010 /* END=0x0010, size 16 */
+  peripheral_8bit  : ORIGIN = 0x0010, LENGTH = 0x00f0 /* END=0x0100, size 240 */
+  peripheral_16bit : ORIGIN = 0x0100, LENGTH = 0x0100 /* END=0x0200, size 256 */
+  bsl              : ORIGIN = 0x1000, LENGTH = 0x0800 /* END=0x1800, size 2K as 4 512-byte segments */
+  infomem          : ORIGIN = 0x1800, LENGTH = 0x0200 /* END=0x1a00, size 512 as 4 128-byte segments */
+  infod            : ORIGIN = 0x1800, LENGTH = 0x0080 /* END=0x1880, size 128 */
+  infoc            : ORIGIN = 0x1880, LENGTH = 0x0080 /* END=0x1900, size 128 */
+  infob            : ORIGIN = 0x1900, LENGTH = 0x0080 /* END=0x1980, size 128 */
+  infoa            : ORIGIN = 0x1980, LENGTH = 0x0080 /* END=0x1a00, size 128 */
+  usbram (wx)      : ORIGIN = 0x1c00, LENGTH = 0x0800 /* END=0x2400, size 2K */
+  ram (wx)         : ORIGIN = 0x2400, LENGTH = 0x2000 /* END=0x4400, size 8K */
+  rom (rx)         : ORIGIN = 0x4400, LENGTH = 0xbb80 /* END=0xff80, size 48000 */
+  vectors          : ORIGIN = 0xff80, LENGTH = 0x0080 /* END=0x10000, size 128 as 64 2-byte segments */
+  far_rom          : ORIGIN = 0x00010000, LENGTH = 0x00014400 /* END=0x00024400, size 81K */
+  /* Remaining banks are absent */
+  ram2 (wx)        : ORIGIN = 0x0000, LENGTH = 0x0000
+  ram_mirror (wx)  : ORIGIN = 0x0000, LENGTH = 0x0000
+  signature        : ORIGIN = 0x0000, LENGTH = 0x0000
+}
+REGION_ALIAS("REGION_TEXT", rom);
+REGION_ALIAS("REGION_DATA", ram);
+REGION_ALIAS("REGION_FAR_ROM", far_rom); /* Legacy name, no longer used */
+REGION_ALIAS("REGION_FAR_TEXT", far_rom);
+REGION_ALIAS("REGION_FAR_DATA", ram2);
+PROVIDE (__info_segment_size = 0x80);
+PROVIDE (__infod = 0x1800);
+PROVIDE (__infoc = 0x1880);
+PROVIDE (__infob = 0x1900);
+PROVIDE (__infoa = 0x1980);


### PR DESCRIPTION
kubos-rt-example doesn't work on the MSP430F5529 anymore because the memory map was changed and is now too small.

I fixed it by copying all the MSP430 fixes from Marshall's PR #34 