### PR TITLE
KUBOS-520 Adding Kubos CI Dockerfile

### DIFF
--- a/tools/dist/Dockerfile
+++ b/tools/dist/Dockerfile
@@ -35,7 +35,8 @@ RUN rm ./iobc_toolchain.tar.gz
 
 RUN pip install pysocks
 RUN pip install mock
-RUN pip install kubos-cli
+RUN pip install --upgrade setuptools
+RUN pip install git+https://github.com/kubostech/kubos-cli
 
 RUN mkdir -p /usr/local/lib/yotta_modules
 RUN mkdir -p /usr/local/lib/yotta_targets

--- a/tools/dist/Dockerfile
+++ b/tools/dist/Dockerfile
@@ -1,0 +1,44 @@
+FROM phusion/baseimage:0.9.18
+
+MAINTAINER kyle@kubos.co
+
+RUN add-apt-repository -y ppa:team-gcc-arm-embedded/ppa
+RUN add-apt-repository -y ppa:george-edison55/cmake-3.x
+RUN add-apt-repository -y ppa:git-core/ppa
+RUN add-apt-repository -y ppa:fkrull/deadsnakes-python2.7
+
+RUN apt-get update -y
+
+RUN apt-get upgrade -y python2.7
+RUN apt-get install -y build-essential libssl-dev libffi-dev libhidapi-hidraw0 clang
+RUN apt-get install -y python-setuptools build-essential ninja-build python-dev libffi-dev libssl-dev
+RUN apt-get install -y gcc-arm-embedded
+RUN apt-get install -y git
+RUN apt-get install -y cmake
+RUN apt-get install -y gcc-msp430 gdb-msp430 msp430-libc
+
+RUN apt-get install -y unzip wget
+
+#do the pip setup and installation things
+RUN easy_install pip
+RUN pip install --upgrade pip
+
+#KubOS Linux setup
+RUN echo "Installing KubOS Linux Toolchain"
+
+RUN apt-get install -y minicom
+RUN apt-get install -y libc6-i386 lib32stdc++6 lib32z1
+
+RUN wget http://portal.kubos.co/bin/iobc_toolchain.tar.gz
+RUN tar -xf ./iobc_toolchain.tar.gz -C /usr/bin
+RUN rm ./iobc_toolchain.tar.gz
+
+RUN pip install pysocks
+RUN pip install mock
+RUN pip install kubos-cli
+
+RUN mkdir -p /usr/local/lib/yotta_modules
+RUN mkdir -p /usr/local/lib/yotta_targets
+RUN mkdir -p /home/vagrant/.kubos
+
+ENV PATH "$PATH:/usr/bin/iobc_toolchain/usr/bin"

--- a/tools/dist/programs.json
+++ b/tools/dist/programs.json
@@ -1,0 +1,8 @@
+{
+    "programs": [
+        "msp430-gcc",
+        "arm-none-eabi-gcc",
+        "arm-none-eabi-gdb",
+        "arm-linux-gcc"
+    ]
+}

--- a/tools/dist/version_check.py
+++ b/tools/dist/version_check.py
@@ -1,0 +1,76 @@
+#!/usr/bin/python
+import argparse
+import docker
+import json
+import os
+import sys
+import re
+
+from .. import utils
+
+'''
+This is a utility for checking the versions of utilities in a docker image (kubostech/kubos-dev)
+against a vagrant environment. The path to the environment needs to be provided as an argument to
+this script.
+
+It reads in programs to test from the programs.json file. Add or remove programs from that list as
+necessary.
+
+Usage:
+$ cd <kubos repo root>
+$ python -m tools.dist.version_check <path-to-vagrant-environment>
+'''
+
+
+class VersionCheck(object):
+    docker_image = 'kubostech/kubos-dev:latest'
+    json_file = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'programs.json')
+    client = docker.from_env()
+    pattern = re.compile(r'\s+')
+
+    def __init__(self, vagrant_path):
+        self.vagrantfile = vagrant_path
+        with open(self.json_file, 'r') as json_file:
+            self.programs = json.loads(json_file.read())['programs']
+        os.chdir(vagrant_path)
+
+
+    def check_versions(self):
+        print 'Starting version checking...'
+        for prog in self.programs:
+            self.check_version(prog)
+
+
+    def check_version(self, program):
+        #these are the easy to read versions
+        vagrant_version = self.check_vagrant_version(program)
+        docker_version  = self.check_docker_version(program)
+        #differences in whitespace screw up the comparison
+        comp_docker_version  = re.sub(self.pattern, '', docker_version)
+        comp_vagrant_version = re.sub(self.pattern, '', vagrant_version)
+        if comp_vagrant_version == comp_docker_version:
+            print 'Found Matching version: %s' % program
+        else:
+            print 'FAILED: Program %s, Vagrant version: %s Docker version: %s' % (program, vagrant_version, docker_version)
+
+
+    def check_vagrant_version(self, program):
+        FDNULL = open(os.devnull, 'w')
+        return utils.cmd('vagrant', 'ssh', '-c', '%s --version' % program, save_output=True, echo=False, stderr=FDNULL)
+
+
+    def check_docker_version(self, program):
+        return self.client.containers.run('kubostech/kubos-dev', '%s --version' % program)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('vagrant_file', help='Specify the path to the Vagrant environment you want to sanity check')
+    args, unknown_args = parser.parse_known_args()
+
+    checker = VersionCheck(args.vagrant_file)
+    checker.check_versions()
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
 Mirrors the Vagrant environment only for standard kubos projects (no linux dependencies).

This is a slightly stripped down (the linux dependencies have been removed) image that has been running in our CI builds for the kubos and kubos-linux-build repos.