### PR TITLE
[KUBOS-486] Adding quick start tutorial to main page

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -95,7 +95,7 @@ html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-#html_static_path = ['_static']
+html_static_path = ['_static']
 
 
 # -- Options for HTMLHelp output ------------------------------------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -19,11 +19,10 @@ Quick Start Tutorial
 --------------------
   
 .. raw:: html
-    
-    <video width="640" height="480" controls>
-      <source src="_static/kubos-quickstart-tutorial.mp4" type="video/mp4">
-    Your browser does not support the video tag.
-    </video>
+
+    <iframe width="640" height="480" allowfullscreen
+    src="https://www.youtube.com/embed/WYthDHETmBU">
+    </iframe>
     
 This video is intended to help you set up your Kubos SDK development 
 environment and get your first project built and running on an end-point

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,6 +15,24 @@ us! <https://slack.kubos.co/>`__
 If for some reason Slack won't work for you, feel free to email us at
 info@kubos.co.
 
+Quick Start Tutorial
+--------------------
+  
+.. raw:: html
+    
+    <video width="640" height="480" controls>
+      <source src="_static/kubos-quickstart-tutorial.mp4" type="video/mp4">
+    Your browser does not support the video tag.
+    </video>
+    
+This video is intended to help you set up your Kubos SDK development 
+environment and get your first project built and running on an end-point
+device.
+It covers the following tutorial documents:
+
+  - :doc:`Installing the Kubos SDK <sdk-installing>`
+  - :doc:`Creating Your First Project <first-project>`
+
 .. toctree::
    :caption: Docs
    :hidden:

--- a/docs/kubos-linux-upgrade.rst
+++ b/docs/kubos-linux-upgrade.rst
@@ -150,7 +150,7 @@ From the KubOS Linux shell:
 
 ::
 
-    $ fw_printenv kubos_updatefile kpack-{desired version}.itb
+    $ fw_setenv kubos_updatefile kpack-{desired version}.itb
     $ reboot
 
 Upgrade Creation

--- a/docs/kubos-standards.rst
+++ b/docs/kubos-standards.rst
@@ -6,7 +6,7 @@ This is a doc to maintain the current naming and coding standards when
 working with the Kubos products.
 
 Product Names
--------------
+#############
 
 The general naming scheme is "Kub[OS\|os] {component}". Note that there
 is a space separating the two words.
@@ -31,7 +31,7 @@ For example:
 - Kubos Core
 
 File Naming
------------
+###########
 
 Code (\*.c, \*.h, scripts, etc)
 -------------------------------
@@ -63,8 +63,7 @@ The CONTRIUBUTING, LICENSE, and README files should all be uppercased.
 be cased to match industry standards.
 
 Them's Fightin' Words
----------------------
-
+#####################
 A few of the more *controversial* rules:
 
 -  Spaces, not tabs
@@ -74,7 +73,7 @@ A few of the more *controversial* rules:
 -  Single space after periods and colons
 
 Documentation Standards
------------------------
+#######################
 
 While creating clean and maintainable code is a high priority for our
 organization, writing successful documentation can be considered even
@@ -132,7 +131,7 @@ Some items to remember:
 -  Oxford commas should **always** be used
 
 Coding Standards
-----------------
+################
 
 This section covers the styling and standards for the various languages
 and tools that we use.
@@ -516,7 +515,7 @@ Use 4 spaces, since that's what we do in all of our other languages.
 `KConfig <https://www.kernel.org/doc/Documentation/kbuild/kconfig-language.txt>`__
 
 CONSISTENCY
------------
+###########
 
 BE CONSISTENT. I DON'T CARE IF YOU IGNORE EVERY OTHER RULE IN THIS DOC
 (okay, I do care, but I'm trying to make a point), JUST MAKE SURE THAT


### PR DESCRIPTION
Created new docs/_static folder to house the tutorial video. Might want to pursue hosting videos elsewhere in the future.

Created in conjunction with issue #121 

Misc:
  - Fixing standards doc headers to have correct levels
  - Fixing random typo in upgrade doc