### PR TITLE
Fixing a bug in the version regex that incorrectly classified tag types

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -8,7 +8,7 @@ echo "Latest tag: $latest_tag"
 #Stable releases follow major.minor.patch version format
 major_regex='^[0-9]+\.[0-9]+\.[0-9]$'
 #Unstable (CD) releases follow major.minor.patch.build version format
-build_regex='^[0-9]+\.[0-9]+\.[0-9]\.[0-9]$'
+build_regex='^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$'
 
 if [[ $latest_tag =~ $major_regex ]];
 then


### PR DESCRIPTION
More than 1 digit in the build (and the patch) field broke the regex that classified tag types preventing tags from being pushed.

