### PR TITLE
Fixed example links to documentation

### DIFF
--- a/examples/kubos-csp-example/README.md
+++ b/examples/kubos-csp-example/README.md
@@ -112,12 +112,12 @@ The red light on that board should blink, followed by the green light on the oth
 For more information about the SDK, see our docs:
 
 - [Kubos Docs](http://docs.kubos.co)
-- [Installing the Kubos SDK](http://docs.kubos.co/1.0.0/sdk-installing.html)
-- [Kubos SDK Cheatsheet](http://docs.kubos.co/1.0.0/sdk-cheatsheet.html) 
-- [Kubos CLI Command Reference](http://docs.kubos.co/sdk-reference.html) 
-- [Kubos Project Configuration](http://docs.kubos.co/1.0.0/sdk-project-config.html)
-- [STM32F4 Discovery Board Guide](http://docs.kubos.co/1.0.0/stm32f4-discovery-board-guide.html) 
-- [MSP430 Launchpad Guide](http://docs.kubos.co/1.0.0/msp430-launchpad-guide.html) 
+- [Installing the Kubos SDK](http://docs.kubos.co/latest/sdk-installing.html)
+- [Kubos SDK Cheatsheet](http://docs.kubos.co/latest/sdk-cheatsheet.html) 
+- [Kubos CLI Command Reference](http://docs.kubos.co/latest/sdk-reference.html) 
+- [Kubos Project Configuration](http://docs.kubos.co/latest/sdk-project-config.html)
+- [STM32F4 Discovery Board Guide](http://docs.kubos.co/latest/stm32f4-discovery-board-guide.html) 
+- [MSP430 Launchpad Guide](http://docs.kubos.co/latest/msp430-launchpad-guide.html) 
 
     
     

--- a/examples/kubos-csp-example/README.md
+++ b/examples/kubos-csp-example/README.md
@@ -111,13 +111,13 @@ The red light on that board should blink, followed by the green light on the oth
 
 For more information about the SDK, see our docs:
 
-- [Kubos Docs](docs.kubos.co)
-- [Installing the Kubos SDK](docs.kubos.co/sdk-installing.html)
-- [Kubos SDK Cheatsheet](docs.kubos.co/sdk-cheatsheet.html) 
-- [Kubos CLI Command Reference](docs.kubos.co/sdk-reference.html) 
-- [Kubos Project Configuration](docs.kubos.co/sdk-project-config.html)
-- [STM32F4 Discovery Board Guide](docs.kubos.co/stm32f4-discovery-board-guide.html) 
-- [MSP430 Launchpad Guide](docs.kubos.co/msp430-launchpad-guide.html) 
+- [Kubos Docs](http://docs.kubos.co)
+- [Installing the Kubos SDK](http://docs.kubos.co/1.0.0/sdk-installing.html)
+- [Kubos SDK Cheatsheet](http://docs.kubos.co/1.0.0/sdk-cheatsheet.html) 
+- [Kubos CLI Command Reference](http://docs.kubos.co/sdk-reference.html) 
+- [Kubos Project Configuration](http://docs.kubos.co/1.0.0/sdk-project-config.html)
+- [STM32F4 Discovery Board Guide](http://docs.kubos.co/1.0.0/stm32f4-discovery-board-guide.html) 
+- [MSP430 Launchpad Guide](http://docs.kubos.co/1.0.0/msp430-launchpad-guide.html) 
 
     
     

--- a/examples/kubos-i2c-example/README.md
+++ b/examples/kubos-i2c-example/README.md
@@ -75,10 +75,10 @@ See the [STM32F4 discovery board Guide](docs.kubos.co/stm32f4-discovery-board-gu
 For more information about the SDK, see our docs:
 
 - [Kubos Docs](http://docs.kubos.co)
-- [Installing the Kubos SDK](http://docs.kubos.co/1.0.0/sdk-installing.html)
-- [Kubos SDK Cheatsheet](http://docs.kubos.co/1.0.0/sdk-cheatsheet.html) 
-- [Kubos CLI Command Reference](http://docs.kubos.co/1.0.0/sdk-reference.html) 
-- [Kubos Project Configuration](http://docs.kubos.co/1.0.0/sdk-project-config.html)
-- [Kubos HAL I2C Guide](http://docs.kubos.co/1.0.0/kubos-hal/i2c.html)
-- [STM32F4 Discovery Board Guide](http://docs.kubos.co/1.0.0/stm32f4-discovery-board-guide.html) 
-- [MSP430 Launchpad Guide](http://docs.kubos.co/1.0.0/msp430-launchpad-guide.html) 
+- [Installing the Kubos SDK](http://docs.kubos.co/latest/sdk-installing.html)
+- [Kubos SDK Cheatsheet](http://docs.kubos.co/latest/sdk-cheatsheet.html) 
+- [Kubos CLI Command Reference](http://docs.kubos.co/latest/sdk-reference.html) 
+- [Kubos Project Configuration](http://docs.kubos.co/latest/sdk-project-config.html)
+- [Kubos HAL I2C Guide](http://docs.kubos.co/latest/kubos-hal/i2c.html)
+- [STM32F4 Discovery Board Guide](http://docs.kubos.co/latest/stm32f4-discovery-board-guide.html) 
+- [MSP430 Launchpad Guide](http://docs.kubos.co/latest/msp430-launchpad-guide.html) 

--- a/examples/kubos-i2c-example/README.md
+++ b/examples/kubos-i2c-example/README.md
@@ -74,11 +74,11 @@ See the [STM32F4 discovery board Guide](docs.kubos.co/stm32f4-discovery-board-gu
 
 For more information about the SDK, see our docs:
 
-- [Kubos Docs](docs.kubos.co)
-- [Installing the Kubos SDK](docs.kubos.co/sdk-installing.html)
-- [Kubos SDK Cheatsheet](docs.kubos.co/sdk-cheatsheet.html) 
-- [Kubos CLI Command Reference](docs.kubos.co/sdk-reference.html) 
-- [Kubos Project Configuration](docs.kubos.co/sdk-project-config.html)
-- [Kubos HAL I2C Guide](http://docs.kubos.co/kubos-hal/i2c.html)
-- [STM32F4 Discovery Board Guide](docs.kubos.co/stm32f4-discovery-board-guide.html) 
-- [MSP430 Launchpad Guide](docs.kubos.co/msp430-launchpad-guide.html) 
+- [Kubos Docs](http://docs.kubos.co)
+- [Installing the Kubos SDK](http://docs.kubos.co/1.0.0/sdk-installing.html)
+- [Kubos SDK Cheatsheet](http://docs.kubos.co/1.0.0/sdk-cheatsheet.html) 
+- [Kubos CLI Command Reference](http://docs.kubos.co/1.0.0/sdk-reference.html) 
+- [Kubos Project Configuration](http://docs.kubos.co/1.0.0/sdk-project-config.html)
+- [Kubos HAL I2C Guide](http://docs.kubos.co/1.0.0/kubos-hal/i2c.html)
+- [STM32F4 Discovery Board Guide](http://docs.kubos.co/1.0.0/stm32f4-discovery-board-guide.html) 
+- [MSP430 Launchpad Guide](http://docs.kubos.co/1.0.0/msp430-launchpad-guide.html) 

--- a/examples/kubos-rt-example/README.md
+++ b/examples/kubos-rt-example/README.md
@@ -60,11 +60,11 @@ indicate a message has been received.
 
 For more information about the SDK, see our docs:
 
-- [Kubos Docs](docs.kubos.co)
-- [Installing the Kubos SDK](docs.kubos.co/sdk-installing.html)
-- [Kubos SDK Cheatsheet](docs.kubos.co/sdk-cheatsheet.html) 
-- [Kubos CLI Command Reference](docs.kubos.co/sdk-reference.html) 
-- [Kubos Project Configuration](docs.kubos.co/sdk-project-config.html)
-- [Kubos HAL I2C Guide](http://docs.kubos.co/kubos-hal/i2c.html)
-- [STM32F4 Discovery Board Guide](docs.kubos.co/stm32f4-discovery-board-guide.html) 
-- [MSP430 Launchpad Guide](docs.kubos.co/msp430-launchpad-guide.html) 
+- [Kubos Docs](http://docs.kubos.co)
+- [Installing the Kubos SDK](http://docs.kubos.co/1.0.0/sdk-installing.html)
+- [Kubos SDK Cheatsheet](http://docs.kubos.co/1.0.0/sdk-cheatsheet.html) 
+- [Kubos CLI Command Reference](http://docs.kubos.co/1.0.0/sdk-reference.html) 
+- [Kubos Project Configuration](http://docs.kubos.co/1.0.0/sdk-project-config.html)
+- [Kubos HAL I2C Guide](http://docs.kubos.co/1.0.0/kubos-hal/i2c.html)
+- [STM32F4 Discovery Board Guide](http://docs.kubos.co/1.0.0/stm32f4-discovery-board-guide.html) 
+- [MSP430 Launchpad Guide](http://docs.kubos.co/1.0.0/msp430-launchpad-guide.html) 

--- a/examples/kubos-rt-example/README.md
+++ b/examples/kubos-rt-example/README.md
@@ -61,10 +61,10 @@ indicate a message has been received.
 For more information about the SDK, see our docs:
 
 - [Kubos Docs](http://docs.kubos.co)
-- [Installing the Kubos SDK](http://docs.kubos.co/1.0.0/sdk-installing.html)
-- [Kubos SDK Cheatsheet](http://docs.kubos.co/1.0.0/sdk-cheatsheet.html) 
-- [Kubos CLI Command Reference](http://docs.kubos.co/1.0.0/sdk-reference.html) 
-- [Kubos Project Configuration](http://docs.kubos.co/1.0.0/sdk-project-config.html)
-- [Kubos HAL I2C Guide](http://docs.kubos.co/1.0.0/kubos-hal/i2c.html)
-- [STM32F4 Discovery Board Guide](http://docs.kubos.co/1.0.0/stm32f4-discovery-board-guide.html) 
-- [MSP430 Launchpad Guide](http://docs.kubos.co/1.0.0/msp430-launchpad-guide.html) 
+- [Installing the Kubos SDK](http://docs.kubos.co/latest/sdk-installing.html)
+- [Kubos SDK Cheatsheet](http://docs.kubos.co/latest/sdk-cheatsheet.html) 
+- [Kubos CLI Command Reference](http://docs.kubos.co/latest/sdk-reference.html) 
+- [Kubos Project Configuration](http://docs.kubos.co/latest/sdk-project-config.html)
+- [Kubos HAL I2C Guide](http://docs.kubos.co/latest/kubos-hal/i2c.html)
+- [STM32F4 Discovery Board Guide](http://docs.kubos.co/latest/stm32f4-discovery-board-guide.html) 
+- [MSP430 Launchpad Guide](http://docs.kubos.co/latest/msp430-launchpad-guide.html) 

--- a/examples/kubos-sd-example/README.md
+++ b/examples/kubos-sd-example/README.md
@@ -78,10 +78,10 @@ debug console and see the output from this project.
 For more information about the SDK, see our docs:
 
 - [Kubos Docs](http://docs.kubos.co)
-- [Installing the Kubos SDK](http://docs.kubos.co/1.0.0/sdk-installing.html)
-- [Kubos SDK Cheatsheet](http://docs.kubos.co/1.0.0/sdk-cheatsheet.html) 
-- [Kubos CLI Command Reference](http://docs.kubos.co/1.0.0/sdk-reference.html) 
-- [Kubos Project Configuration](http://docs.kubos.co/1.0.0/sdk-project-config.html)
-- [Kubos HAL I2C Guide](http://docs.kubos.co/1.0.0/kubos-hal/i2c.html)
-- [STM32F4 Discovery Board Guide](http://docs.kubos.co/1.0.0/stm32f4-discovery-board-guide.html) 
-- [MSP430 Launchpad Guide](http://docs.kubos.co/1.0.0/msp430-launchpad-guide.html) 
+- [Installing the Kubos SDK](http://docs.kubos.co/latest/sdk-installing.html)
+- [Kubos SDK Cheatsheet](http://docs.kubos.co/latest/sdk-cheatsheet.html) 
+- [Kubos CLI Command Reference](http://docs.kubos.co/latest/sdk-reference.html) 
+- [Kubos Project Configuration](http://docs.kubos.co/latest/sdk-project-config.html)
+- [Kubos HAL I2C Guide](http://docs.kubos.co/latest/kubos-hal/i2c.html)
+- [STM32F4 Discovery Board Guide](http://docs.kubos.co/latest/stm32f4-discovery-board-guide.html) 
+- [MSP430 Launchpad Guide](http://docs.kubos.co/latest/msp430-launchpad-guide.html) 

--- a/examples/kubos-sd-example/README.md
+++ b/examples/kubos-sd-example/README.md
@@ -77,11 +77,11 @@ debug console and see the output from this project.
 
 For more information about the SDK, see our docs:
 
-- [Kubos Docs](docs.kubos.co)
-- [Installing the Kubos SDK](docs.kubos.co/sdk-installing.html)
-- [Kubos SDK Cheatsheet](docs.kubos.co/sdk-cheatsheet.html) 
-- [Kubos CLI Command Reference](docs.kubos.co/sdk-reference.html) 
-- [Kubos Project Configuration](docs.kubos.co/sdk-project-config.html)
-- [Kubos HAL I2C Guide](http://docs.kubos.co/kubos-hal/i2c.html)
-- [STM32F4 Discovery Board Guide](docs.kubos.co/stm32f4-discovery-board-guide.html) 
-- [MSP430 Launchpad Guide](docs.kubos.co/msp430-launchpad-guide.html) 
+- [Kubos Docs](http://docs.kubos.co)
+- [Installing the Kubos SDK](http://docs.kubos.co/1.0.0/sdk-installing.html)
+- [Kubos SDK Cheatsheet](http://docs.kubos.co/1.0.0/sdk-cheatsheet.html) 
+- [Kubos CLI Command Reference](http://docs.kubos.co/1.0.0/sdk-reference.html) 
+- [Kubos Project Configuration](http://docs.kubos.co/1.0.0/sdk-project-config.html)
+- [Kubos HAL I2C Guide](http://docs.kubos.co/1.0.0/kubos-hal/i2c.html)
+- [STM32F4 Discovery Board Guide](http://docs.kubos.co/1.0.0/stm32f4-discovery-board-guide.html) 
+- [MSP430 Launchpad Guide](http://docs.kubos.co/1.0.0/msp430-launchpad-guide.html) 

--- a/examples/kubos-sensor-example/README.md
+++ b/examples/kubos-sensor-example/README.md
@@ -71,10 +71,10 @@ Create a minicom session in order to connect to your board and see the project o
 
 For more information about the SDK, see our docs:
 
-- [Kubos Docs](docs.kubos.co)
-- [Installing the Kubos SDK](docs.kubos.co/sdk-installing.html)
-- [Kubos SDK Cheatsheet](docs.kubos.co/sdk-cheatsheet.html) 
-- [Kubos CLI Command Reference](docs.kubos.co/sdk-reference.html) 
-- [Kubos Project Configuration](docs.kubos.co/sdk-project-config.html)
-- [STM32F4 Discovery Board Guide](docs.kubos.co/stm32f4-discovery-board-guide.html) 
+- [Kubos Docs](http://docs.kubos.co)
+- [Installing the Kubos SDK](http://docs.kubos.co/1.0.0/sdk-installing.html)
+- [Kubos SDK Cheatsheet](http://docs.kubos.co/1.0.0/sdk-cheatsheet.html) 
+- [Kubos CLI Command Reference](http://docs.kubos.co/1.0.0/sdk-reference.html) 
+- [Kubos Project Configuration](http://docs.kubos.co/1.0.0/sdk-project-config.html)
+- [STM32F4 Discovery Board Guide](http://docs.kubos.co/1.0.0/stm32f4-discovery-board-guide.html) 
 

--- a/examples/kubos-sensor-example/README.md
+++ b/examples/kubos-sensor-example/README.md
@@ -72,9 +72,9 @@ Create a minicom session in order to connect to your board and see the project o
 For more information about the SDK, see our docs:
 
 - [Kubos Docs](http://docs.kubos.co)
-- [Installing the Kubos SDK](http://docs.kubos.co/1.0.0/sdk-installing.html)
-- [Kubos SDK Cheatsheet](http://docs.kubos.co/1.0.0/sdk-cheatsheet.html) 
-- [Kubos CLI Command Reference](http://docs.kubos.co/1.0.0/sdk-reference.html) 
-- [Kubos Project Configuration](http://docs.kubos.co/1.0.0/sdk-project-config.html)
-- [STM32F4 Discovery Board Guide](http://docs.kubos.co/1.0.0/stm32f4-discovery-board-guide.html) 
+- [Installing the Kubos SDK](http://docs.kubos.co/latest/sdk-installing.html)
+- [Kubos SDK Cheatsheet](http://docs.kubos.co/latest/sdk-cheatsheet.html) 
+- [Kubos CLI Command Reference](http://docs.kubos.co/latest/sdk-reference.html) 
+- [Kubos Project Configuration](http://docs.kubos.co/latest/sdk-project-config.html)
+- [STM32F4 Discovery Board Guide](http://docs.kubos.co/latest/stm32f4-discovery-board-guide.html) 
 

--- a/examples/kubos-spi-example/README.md
+++ b/examples/kubos-spi-example/README.md
@@ -74,9 +74,9 @@ Create a minicom session in order to connect to your board and see the project o
 For more information about the SDK, see our docs:
 
 - [Kubos Docs](http://docs.kubos.co)
-- [Installing the Kubos SDK](http://docs.kubos.co/1.0.0/sdk-installing.html)
-- [Kubos SDK Cheatsheet](http://docs.kubos.co/1.0.0/sdk-cheatsheet.html) 
-- [Kubos CLI Command Reference](http://docs.kubos.co/1.0.0/sdk-reference.html) 
-- [Kubos Project Configuration](http://docs.kubos.co/1.0.0/sdk-project-config.html)
-- [Kubos HAL SPI Guide](http://http://docs.kubos.co/1.0.0/kubos-hal/spi.html)
-- [STM32F4 Discovery Board Guide](http://docs.kubos.co/1.0.0/stm32f4-discovery-board-guide.html)
+- [Installing the Kubos SDK](http://docs.kubos.co/latest/sdk-installing.html)
+- [Kubos SDK Cheatsheet](http://docs.kubos.co/latest/sdk-cheatsheet.html) 
+- [Kubos CLI Command Reference](http://docs.kubos.co/latest/sdk-reference.html) 
+- [Kubos Project Configuration](http://docs.kubos.co/latest/sdk-project-config.html)
+- [Kubos HAL SPI Guide](http://http://docs.kubos.co/latest/kubos-hal/spi.html)
+- [STM32F4 Discovery Board Guide](http://docs.kubos.co/latest/stm32f4-discovery-board-guide.html)

--- a/examples/kubos-spi-example/README.md
+++ b/examples/kubos-spi-example/README.md
@@ -73,10 +73,10 @@ Create a minicom session in order to connect to your board and see the project o
 
 For more information about the SDK, see our docs:
 
-- [Kubos Docs](docs.kubos.co)
-- [Installing the Kubos SDK](docs.kubos.co/sdk-installing.html)
-- [Kubos SDK Cheatsheet](docs.kubos.co/sdk-cheatsheet.html) 
-- [Kubos CLI Command Reference](docs.kubos.co/sdk-reference.html) 
-- [Kubos Project Configuration](docs.kubos.co/sdk-project-config.html)
-- [Kubos HAL SPI Guide](http://docs.kubos.co/kubos-hal/spi.html)
-- [STM32F4 Discovery Board Guide](docs.kubos.co/stm32f4-discovery-board-guide.html)
+- [Kubos Docs](http://docs.kubos.co)
+- [Installing the Kubos SDK](http://docs.kubos.co/1.0.0/sdk-installing.html)
+- [Kubos SDK Cheatsheet](http://docs.kubos.co/1.0.0/sdk-cheatsheet.html) 
+- [Kubos CLI Command Reference](http://docs.kubos.co/1.0.0/sdk-reference.html) 
+- [Kubos Project Configuration](http://docs.kubos.co/1.0.0/sdk-project-config.html)
+- [Kubos HAL SPI Guide](http://http://docs.kubos.co/1.0.0/kubos-hal/spi.html)
+- [STM32F4 Discovery Board Guide](http://docs.kubos.co/1.0.0/stm32f4-discovery-board-guide.html)


### PR DESCRIPTION
I added the http:// extension to the documentation links and the 1.0.0 part after the hostname so that the links actually work on all the example projects