### PR TITLE
Removing SPI0 from BBB. Adding small doc updates

### DIFF
--- a/docs/kubos-linux-on-bbb.rst
+++ b/docs/kubos-linux-on-bbb.rst
@@ -243,11 +243,17 @@ The KubOS Linux installation process is composed of two high-level steps:
 To perform a full default installation, two files are needed:
 
   - A KubOS Linux SD card image
-  - An aux_sd1 image
+  - An aux_sd image
   
 All of these files can be obtained from `our KubOS Linux Releases page on GitHub <https://github.com/kubostech/kubos-linux-build/releases>`__
 
 Download the latest `KubOS_Linux.zip` file and then unzip the files for the Beaglebone Black. They're located in the `KubOS_Linux/{version}/Beaglebone-Black` folder.
+
+.. note::
+
+    The Beaglebone Black can also be used as a development board for the Pumpkin MBM2.
+    If you would like to use it for this purpose, please follow the
+    :ref:`installation instructions for the MBM2 <installation-process-mbm2>` instead.
 
 Pre-Requisites
 ~~~~~~~~~~~~~~
@@ -355,6 +361,10 @@ Now flash the micro SD card with the auxiliary SD card image. This image contain
 KubOS Linux upgrade partition and the second user data partition.
 
 Once the flash process has completed, put the card back into the microSD slot.
+
+.. warning::
+
+    If you do not have a microSD card in the board, the system will not boot.
 
 The installation process is now complete.
 

--- a/docs/kubos-linux-on-mbm2.rst
+++ b/docs/kubos-linux-on-mbm2.rst
@@ -246,7 +246,7 @@ The KubOS Linux installation process is composed of two high-level steps:
 To perform a full default installation, two files are needed:
 
   - A KubOS Linux SD card image
-  - An aux_sd1 image
+  - An aux_sd image
   
 All of these files can be obtained from `our KubOS Linux Releases page on GitHub <https://github.com/kubostech/kubos-linux-build/releases>`__
 
@@ -358,6 +358,10 @@ Now flash the micro SD card with the auxiliary SD card image. This image contain
 KubOS Linux upgrade partition and the second user data partition.
 
 Once the flash process has completed, put the card back into the microSD slot.
+
+.. warning::
+
+    If you do not have a microSD card in the board, the system will not boot.
 
 The installation process is now complete.
 

--- a/docs/working-with-the-bbb.rst
+++ b/docs/working-with-the-bbb.rst
@@ -48,8 +48,10 @@ in the future to abstract this process.
 .. note::
 
     KubOS Linux for the Pumpkin MBM2 can be used instead of KubOS Linux
-    for the Beaglebone Black. In this case, some peripherals won't be
-    available. See the :ref:`peripherals-mbm2` section for more information.
+    for the Beaglebone Black. In this case, some buses and pins won't be
+    available, since they aren't exposed in the MBM2's CSK headers, or are
+    dedicated to other uses. See the :ref:`peripherals-mbm2` section for 
+    more information.
     
 UART
 ~~~~
@@ -146,9 +148,9 @@ The Beaglebone has one SPI bus available with two pre-allocated chip select pins
 +------+-------+
 | Name | Pin   |
 +======+=======+
-| MOSI | P9.29 |
+| MOSI | P9.30 |
 +------+-------+
-| MISO | P9.30 |
+| MISO | P9.29 |
 +------+-------+
 | SCLK | P9.31 |
 +------+-------+

--- a/docs/working-with-the-bbb.rst
+++ b/docs/working-with-the-bbb.rst
@@ -45,11 +45,12 @@ with peripheral devices. Currently, users should interact with these
 devices using the standard Linux functions. A Kubos HAL will be added 
 in the future to abstract this process.
 
-.. warning::
+.. note::
 
-    Some pins are re-used by multiple buses. As a result, you will not be
-    able to use all buses simultaneously.
-
+    KubOS Linux for the Pumpkin MBM2 can be used instead of KubOS Linux
+    for the Beaglebone Black. In this case, some peripherals won't be
+    available. See the :ref:`peripherals-mbm2` section for more information.
+    
 UART
 ~~~~
 
@@ -138,21 +139,7 @@ The user program should look something like this:
 SPI
 ~~~
 
-The Beaglebone has two SPI buses available with pre-allocated chip select pins.
-
-**SPI Bus 0**
-
-+------+-------+
-| Name | Pin   |
-+======+=======+
-| MOSI | P9.21 |
-+------+-------+
-| MISO | P9.18 |
-+------+-------+
-| SCLK | P9.22 |
-+------+-------+
-| CS0  | P9.17 |
-+------+-------+
+The Beaglebone has one SPI bus available with two pre-allocated chip select pins.
 
 **SPI Bus 1**
 
@@ -171,8 +158,8 @@ The Beaglebone has two SPI buses available with pre-allocated chip select pins.
 +------+-------+
 
 Users can interact a device on this bus using Linux's `spidev interface <https://www.kernel.org/doc/Documentation/spi/spidev>`__
-The device name will be ``/dev/spidev{bus_number}.{CS_number}``. For example, a device connected to the first chip select pin
-of SPI bus 1 would be ``/dev/spidev1.0``.
+The device name will be ``/dev/spidev1.{CS_number}``. For example, a device 
+connected to the first chip select pin would be ``/dev/spidev1.0``.
 
 An example user program to read a value might look like this:
 

--- a/docs/working-with-the-mbm2.rst
+++ b/docs/working-with-the-mbm2.rst
@@ -40,6 +40,8 @@ drivers should be automatically installed.
 This connection will be passed through to a Kubos Vagrant image as
 `/dev/FTDI` and will be used for the serial console.
 
+.. _peripherals-mbm2:
+
 Peripherals
 -----------
 


### PR DESCRIPTION
Updating documentation to remove the SPI0 bus from the Beaglebone Black documentation. It was removed from the board because the pins conflict with I2C1.

Also adding some small notes that have been in my head.