### PR TITLE
Typo in documentation

### DIFF
--- a/docs/working-with-the-bbb.rst
+++ b/docs/working-with-the-bbb.rst
@@ -363,7 +363,7 @@ An example program might look like this:
     /* Read the value back */
     fd = open("/sys/class/gpio/gpio45/value", O_RDONLY);
     char strValue[3];
-    write(fd, strValue, 1);
+    read(fd, strValue, 3);
     value = atoi(strValue);
     close(fd);
     


### PR DESCRIPTION
Typo in documentation. Replace write with read.