### PR TITLE
took out all prerequisites except the link to setting up the SDK

### DIFF
--- a/docs/first-linux-project.rst
+++ b/docs/first-linux-project.rst
@@ -9,20 +9,6 @@ Prerequisites
 
 :doc:`Install the Kubos SDK <sdk-installing>`
 
-Create an instance of the Kubos Vagrant box
-
-::
-
-        $ vagrant init kubostech/kubos-dev
-
-SSH into your box
-
-::
-
-        $ vagrant ssh
-
-At this point you will have a new terminal prompt inside your kubos-dev box.
-
 Creating your Project
 ---------------------
 

--- a/docs/first-rt-project.rst
+++ b/docs/first-rt-project.rst
@@ -9,21 +9,6 @@ Prerequisites
 
 :doc:`Install the Kubos SDK <sdk-installing>`
 
-Create an instance of the Kubos Vagrant box
-
-::
-
-        $ vagrant init kubostech/kubos-dev
-
-SSH into your box
-
-::
-
-        $ vagrant ssh
-
-At this point you will have a new terminal prompt inside your kubos-dev
-box.
-
 Creating your Project
 ---------------------
 


### PR DESCRIPTION
There were duplicate, incomplete instructions in the first project docs. I took out the duplicate instructions and just left the link to the setup doc, which includes the old instructions. 