### PR TITLE
Minor doc tweaks

### DIFF
--- a/docs/kubos-linux-on-bbb.rst
+++ b/docs/kubos-linux-on-bbb.rst
@@ -337,6 +337,7 @@ To flash the eMMC, log into the board and then run these commands:
 ::
 
     $ umount /dev/mmcblk*
+    $ umount /dev/mmcblk*
     $ dd if=/dev/mmcblk0 of=/dev/mmcblk1
     
 The four status LEDs on the board should start flashing in a random pattern. This indicates

--- a/docs/kubos-linux-on-bbb.rst
+++ b/docs/kubos-linux-on-bbb.rst
@@ -143,7 +143,7 @@ for the Beaglebone Black.
 
 ::
 
-    $ sudo make BR2_EXTERNAL=../kubos-linux-build bbb_defconfig
+    $ sudo make BR2_EXTERNAL=../kubos-linux-build beaglebone-black_defconfig
 
 Build everything
 

--- a/docs/kubos-linux-on-bbb.rst
+++ b/docs/kubos-linux-on-bbb.rst
@@ -340,6 +340,11 @@ To flash the eMMC, log into the board and then run these commands:
     $ umount /dev/mmcblk*
     $ dd if=/dev/mmcblk0 of=/dev/mmcblk1
     
+.. note:: 
+
+    There are some nested mapped directories, so the ``umount`` command must be run twice in order to
+    free up all required resources.
+    
 The four status LEDs on the board should start flashing in a random pattern. This indicates
 that the eMMC is currently being flashed. 
 

--- a/docs/kubos-linux-on-bbb.rst
+++ b/docs/kubos-linux-on-bbb.rst
@@ -336,14 +336,9 @@ To flash the eMMC, log into the board and then run these commands:
 
 ::
 
-    $ umount /dev/mmcblk*
-    $ umount /dev/mmcblk*
+    $ umount /home/microsd
+    $ umount /home
     $ dd if=/dev/mmcblk0 of=/dev/mmcblk1
-    
-.. note:: 
-
-    There are some nested mapped directories, so the ``umount`` command must be run twice in order to
-    free up all required resources.
     
 The four status LEDs on the board should start flashing in a random pattern. This indicates
 that the eMMC is currently being flashed. 

--- a/docs/kubos-linux-on-mbm2.rst
+++ b/docs/kubos-linux-on-mbm2.rst
@@ -334,6 +334,7 @@ To flash the eMMC, log into the board and then run these commands:
 ::
 
     $ umount /dev/mmcblk*
+    $ umount /dev/mmcblk*
     $ dd if=/dev/mmcblk0 of=/dev/mmcblk1
     
 The four status LEDs on the board should start flashing in a random pattern. This indicates

--- a/docs/kubos-linux-on-mbm2.rst
+++ b/docs/kubos-linux-on-mbm2.rst
@@ -333,14 +333,9 @@ To flash the eMMC, log into the board and then run these commands:
 
 ::
 
-    $ umount /dev/mmcblk*
-    $ umount /dev/mmcblk*
+    $ umount /home/microsd
+    $ umount /home
     $ dd if=/dev/mmcblk0 of=/dev/mmcblk1
-    
-.. note:: 
-
-    There are some nested mapped directories, so the ``umount`` command must be run twice in order to
-    free up all required resources.
     
 The four status LEDs on the board should start flashing in a random pattern. This indicates
 that the eMMC is currently being flashed. 

--- a/docs/kubos-linux-on-mbm2.rst
+++ b/docs/kubos-linux-on-mbm2.rst
@@ -337,6 +337,11 @@ To flash the eMMC, log into the board and then run these commands:
     $ umount /dev/mmcblk*
     $ dd if=/dev/mmcblk0 of=/dev/mmcblk1
     
+.. note:: 
+
+    There are some nested mapped directories, so the ``umount`` command must be run twice in order to
+    free up all required resources.
+    
 The four status LEDs on the board should start flashing in a random pattern. This indicates
 that the eMMC is currently being flashed. 
 


### PR DESCRIPTION
1. BBB buildroot config name is wrong
2. If currently running KubOS Linux, `umount` command must be run twice in order to successfully transfer the new SD image to the eMMC