### PR TITLE
Initial Telemetry Handler Prototype

### DIFF
--- a/telemetry_handler/README.rst
+++ b/telemetry_handler/README.rst
@@ -1,0 +1,36 @@
+Telemetry+GraphQL Prototype
+===========================
+
+This is a pretty basic prototype of Graphene+SQLAlchemy+Flask
+running against the ICEye telemetry database.
+
+This app expects the database to be in a file named `telem.db`
+in this folder and will attempt to use the table name `Telemetry`.
+
+The default Telemetry table is pretty large and there are no query limits
+built into the code atm. I'd suggest trimming down the table size in the
+database before playing.
+
+
+::
+
+   python ./app.py
+
+This will start a flask server at http://127.0.0.1:5000.
+If you go to http://127.0.0.1:5000/graphql you will find a built-in
+GraphiQL interface.
+
+Valid queries will take the form of
+
+::
+
+   {
+     allTelemetry {
+       edges {
+         node {
+           timestamp,
+           subsystem,
+         }
+       }
+     }
+   }

--- a/telemetry_handler/README.rst
+++ b/telemetry_handler/README.rst
@@ -11,26 +11,37 @@ The default Telemetry table is pretty large and there are no query limits
 built into the code atm. I'd suggest trimming down the table size in the
 database before playing.
 
-
 ::
 
    python ./app.py
 
 This will start a flask server at http://127.0.0.1:5000.
-If you go to http://127.0.0.1:5000/graphql you will find a built-in
+If you go to http://127.0.0.1:5000/graphiql you will find a built-in
 GraphiQL interface.
+
+There is a raw HTTP/GraphQL endpoint found at http://127.0.0.1:5000/graphql.
 
 Valid queries will take the form of
 
 ::
 
    {
-     allTelemetry {
-       edges {
-         node {
-           timestamp,
-           subsystem,
-         }
-       }
+     telemetry {
+       timestamp,
+       subsystem
+     }
+   }
+
+
+Filtering can be done like so
+
+::
+
+   {
+     telemetry(subsystem:"PCM") {
+       timestamp,
+       subsystem,
+       param,
+       value
      }
    }

--- a/telemetry_handler/app.py
+++ b/telemetry_handler/app.py
@@ -12,9 +12,20 @@ app.add_url_rule(
     view_func=GraphQLView.as_view(
         'graphql',
         schema=schema,
+        graphiql=False
+    )
+)
+
+
+app.add_url_rule(
+    '/graphiql',
+    view_func=GraphQLView.as_view(
+        'graphiql',
+        schema=schema,
         graphiql=True
     )
 )
+
 
 @app.teardown_appcontext
 def shutdown_session(exception=None):

--- a/telemetry_handler/app.py
+++ b/telemetry_handler/app.py
@@ -1,0 +1,25 @@
+from flask import Flask
+from flask_graphql import GraphQLView
+
+from models import db_session
+from schema import schema, Telemetry
+
+app = Flask(__name__)
+app.debug = True
+
+app.add_url_rule(
+    '/graphql',
+    view_func=GraphQLView.as_view(
+        'graphql',
+        schema=schema,
+        graphiql=True
+    )
+)
+
+@app.teardown_appcontext
+def shutdown_session(exception=None):
+    db_session.remove()
+
+
+if __name__ == '__main__':
+    app.run()

--- a/telemetry_handler/main.py
+++ b/telemetry_handler/main.py
@@ -1,0 +1,1 @@
+import graphene

--- a/telemetry_handler/models.py
+++ b/telemetry_handler/models.py
@@ -1,14 +1,19 @@
+"""Module for creating db connection and ORM models
+"""
 from sqlalchemy import *
-from sqlalchemy.orm import (scoped_session, sessionmaker, relationship, backref)
+from sqlalchemy.orm import (
+    scoped_session, sessionmaker, relationship, backref)
 
 from sqlalchemy.ext.declarative import declarative_base
 
 engine = create_engine('sqlite:///telem.db', convert_unicode=True)
-db_session = scoped_session(sessionmaker(autocommit=False, autoflush=False, bind=engine))
+db_session = scoped_session(sessionmaker(
+    autocommit=False, autoflush=False, bind=engine))
 
 Base = declarative_base()
 
 Base.query = db_session.query_property()
+
 
 class Telemetry(Base):
     __tablename__ = 'Telemetry'

--- a/telemetry_handler/models.py
+++ b/telemetry_handler/models.py
@@ -1,0 +1,18 @@
+from sqlalchemy import *
+from sqlalchemy.orm import (scoped_session, sessionmaker, relationship, backref)
+
+from sqlalchemy.ext.declarative import declarative_base
+
+engine = create_engine('sqlite:///telem.db', convert_unicode=True)
+db_session = scoped_session(sessionmaker(autocommit=False, autoflush=False, bind=engine))
+
+Base = declarative_base()
+
+Base.query = db_session.query_property()
+
+class Telemetry(Base):
+    __tablename__ = 'Telemetry'
+    timestamp = Column(BigInteger, primary_key=True)
+    subsystem = Column(String)
+    param = Column(String)
+    value = Column(BigInteger)

--- a/telemetry_handler/requirements.txt
+++ b/telemetry_handler/requirements.txt
@@ -1,0 +1,6 @@
+graphene[sqlalchemy]
+SQLAlchemy==1.0.11
+Flask==0.10.1
+Flask-GraphQL==1.3.0
+graphene>=2.0.dev
+graphene-sqlalchemy>=2.0.dev

--- a/telemetry_handler/requirements.txt
+++ b/telemetry_handler/requirements.txt
@@ -2,5 +2,5 @@ graphene[sqlalchemy]
 SQLAlchemy==1.0.11
 Flask==0.10.1
 Flask-GraphQL==1.3.0
-graphene>=2.0.dev
-graphene-sqlalchemy>=2.0.dev
+graphene==2.0
+graphene-sqlalchemy==2.0.0

--- a/telemetry_handler/schema.py
+++ b/telemetry_handler/schema.py
@@ -1,0 +1,30 @@
+import graphene
+from graphene import relay
+from graphene_sqlalchemy import SQLAlchemyObjectType, SQLAlchemyConnectionField
+from models import db_session, Telemetry as TelemetryModel
+
+class Telemetry(SQLAlchemyObjectType):
+    class Meta:
+        model = TelemetryModel
+        interfaces = (relay.Node, )
+
+class TelemConnectionField(SQLAlchemyConnectionField):
+    RELAY_ARGS = ['first', 'last', 'before', 'after']
+
+    @classmethod
+    def get_query(cls, model, context, info, args):
+        query = super(TelemConnectionField, cls).get_query(model, context, info, args)
+        for field, value in args.items():
+            if field not in cls.RELAY_ARGS:
+                query = query.filter(getattr(model, field) == value)
+        return query
+
+class Query(graphene.ObjectType):
+    node = relay.Node.Field()
+    all_telemetry = SQLAlchemyConnectionField(Telemetry)
+    telem_by_subsys = TelemConnectionField(Telemetry,
+                                           subsystem=graphene.String(),
+                                           param=graphene.String())
+
+
+schema = graphene.Schema(query=Query)

--- a/telemetry_handler/schema.py
+++ b/telemetry_handler/schema.py
@@ -2,43 +2,34 @@ import graphene
 from graphene import relay
 from graphene_sqlalchemy import SQLAlchemyObjectType, SQLAlchemyConnectionField
 from models import db_session, Telemetry as TelemetryModel
-""""
-class Telemetry(SQLAlchemyObjectType):
-    class Meta:
-        model = TelemetryModel
-        interfaces = (relay.Node, )
-
-class TelemConnectionField(SQLAlchemyConnectionField):
-    RELAY_ARGS = ['first', 'last', 'before', 'after']
-
-    @classmethod
-    def get_query(cls, model, context, info, args):
-        query = super(TelemConnectionField, cls).get_query(model, context, info, args)
-        for field, value in args.items():
-            if field not in cls.RELAY_ARGS:
-                query = query.filter(getattr(model, field) == value)
-        return query
-
-class Query(graphene.ObjectType):
-    telemetery = TelemConnectionField(Telemetry,
-                                           param=graphene.String(),
-                                           subsystem=graphene.String(),
-                                           timestamp=graphene.Int(),
-                                           value=graphene.Int())
-
-
-schema = graphene.Schema(query=Query)
-"""
 
 class Telemetry(SQLAlchemyObjectType):
     class Meta:
         model = TelemetryModel
 
 class Query(graphene.ObjectType):
-    telemetry = graphene.List(Telemetry)
+    telemetry = graphene.List(Telemetry,
+                              subsystem=graphene.String(),
+                              param=graphene.String(),
+                              timestamp_before=graphene.Float(),
+                              timestamp_after=graphene.Float())
 
-    def resolve_telemetry(self, info, subsystem=None):
-        print("resolving telemetry")
-        return Telemetry.get_query(info).all()
+    def resolve_telemetry(self,
+                          info,
+                          subsystem=None,
+                          param=None,
+                          timestamp_before=None,
+                          timestamp_after=None):
+        model = Telemetry._meta.model
+        query = Telemetry.get_query(info)
+        if subsystem:
+            query = query.filter(model.subsystem == subsystem)
+        if param:
+            query = query.filter(model.param == param)
+        if timestamp_before:
+            query = query.filter(model.timestamp <= timestamp_before)
+        if timestamp_after:
+            query = query.filter(model.timestamp >= timestamp_after)
+        return query.all()
 
 schema = graphene.Schema(query=Query)

--- a/telemetry_handler/schema.py
+++ b/telemetry_handler/schema.py
@@ -2,7 +2,7 @@ import graphene
 from graphene import relay
 from graphene_sqlalchemy import SQLAlchemyObjectType, SQLAlchemyConnectionField
 from models import db_session, Telemetry as TelemetryModel
-
+""""
 class Telemetry(SQLAlchemyObjectType):
     class Meta:
         model = TelemetryModel
@@ -20,12 +20,25 @@ class TelemConnectionField(SQLAlchemyConnectionField):
         return query
 
 class Query(graphene.ObjectType):
-    node = relay.Node.Field()
     telemetery = TelemConnectionField(Telemetry,
                                            param=graphene.String(),
                                            subsystem=graphene.String(),
                                            timestamp=graphene.Int(),
                                            value=graphene.Int())
 
+
+schema = graphene.Schema(query=Query)
+"""
+
+class Telemetry(SQLAlchemyObjectType):
+    class Meta:
+        model = TelemetryModel
+
+class Query(graphene.ObjectType):
+    telemetry = graphene.List(Telemetry)
+
+    def resolve_telemetry(self, info, subsystem=None):
+        print("resolving telemetry")
+        return Telemetry.get_query(info).all()
 
 schema = graphene.Schema(query=Query)

--- a/telemetry_handler/schema.py
+++ b/telemetry_handler/schema.py
@@ -21,10 +21,11 @@ class TelemConnectionField(SQLAlchemyConnectionField):
 
 class Query(graphene.ObjectType):
     node = relay.Node.Field()
-    all_telemetry = SQLAlchemyConnectionField(Telemetry)
-    telem_by_subsys = TelemConnectionField(Telemetry,
+    telemetery = TelemConnectionField(Telemetry,
+                                           param=graphene.String(),
                                            subsystem=graphene.String(),
-                                           param=graphene.String())
+                                           timestamp=graphene.Int(),
+                                           value=graphene.Int())
 
 
 schema = graphene.Schema(query=Query)

--- a/telemetry_handler/schema.py
+++ b/telemetry_handler/schema.py
@@ -1,14 +1,27 @@
+"""
+This module creates the schema bindings between GraphQL queries and
+SQLAlchemy models. In this case there is a single query and single
+binding dealing with the Telemetry table.
+"""
 import graphene
-from graphene import relay
-from graphene_sqlalchemy import SQLAlchemyObjectType, SQLAlchemyConnectionField
-from models import db_session, Telemetry as TelemetryModel
+from graphene_sqlalchemy import SQLAlchemyObjectType
+from models import Telemetry as TelemetryModel
+
 
 class Telemetry(SQLAlchemyObjectType):
+    """Telemetry class for use in Graphene queries
+    """
     class Meta:
+        """Meta class for pointing to TelemetryModel class
+        """
         model = TelemetryModel
 
+
 class Query(graphene.ObjectType):
+    """Query class used to define GraphQL query structures
+    """
     telemetry = graphene.List(Telemetry,
+                              first=graphene.Int(),
                               subsystem=graphene.String(),
                               param=graphene.String(),
                               timestamp_before=graphene.Float(),
@@ -16,12 +29,14 @@ class Query(graphene.ObjectType):
 
     def resolve_telemetry(self,
                           info,
+                          first=None,
                           subsystem=None,
                           param=None,
                           timestamp_before=None,
                           timestamp_after=None):
         model = Telemetry._meta.model
         query = Telemetry.get_query(info)
+        print(type(query))
         if subsystem:
             query = query.filter(model.subsystem == subsystem)
         if param:
@@ -30,6 +45,8 @@ class Query(graphene.ObjectType):
             query = query.filter(model.timestamp <= timestamp_before)
         if timestamp_after:
             query = query.filter(model.timestamp >= timestamp_after)
+        if first:
+            return query.limit(first)
         return query.all()
 
 schema = graphene.Schema(query=Query)


### PR DESCRIPTION
This work represents the initial prototype of a read-only telemetry system. The goal is to create a telemetry handler which is capable of reading from the (pre-existing) ICEYE database, and correctly handle GraphQL queries for fetching telemetry.

- [x] Access Telemetry table from ICEYE database
- [x] Present GraphQL endpoint
- [x] Allow filtering queries on subsystem
- [x] Allow filtering queries on timestamp
- [ ] Add comments/pep8ify