### PR TITLE
Radio API - Moving away from generic pointers

### DIFF
--- a/docs/device-api/radio.rst
+++ b/docs/device-api/radio.rst
@@ -50,8 +50,8 @@ For example:
 Run-Time Radio Configuration
 ----------------------------
 
-Some radios may support or require that the radio be configured during run-time. This can be done by passing a pointer to the
-appropriate configuration structure to the ``k_radio_configure`` function.
+Some radios may support or require that the radio be configured during run-time. This can be done by passing a pointer to 
+a ``radio_config`` structure to the ``k_radio_configure`` function.
 
 Unneeded configuration parameters may be left with zero values to indicate that they should not be changed.
 
@@ -60,14 +60,13 @@ For example:
 .. code-block:: c
 
     #include "radio-api/radio.h"
-    #include "example-radio-api/radio.h"
     
-    example_radio_config config;
+    radio_config config;
     config.data_rate = RADIO_RATE_1200;
-    strncpy(config.to.ascii, "MAJORT", sizeof(((ax25_callsign *)0)->ascii));
-    strncpy(config.from.ascii, "HMLTN1", sizeof(((ax25_callsign *)0)->ascii));
+    strncpy(config.to.ascii, "MAJORT", sizeof(config.to.ascii);
+    strncpy(config.from.ascii, "HMLTN1", sizeof(config.from.ascii);
 
-    k_radio_configure((uint8_t *) &config);
+    k_radio_configure(&config);
     
 Sending a Message
 -----------------
@@ -101,7 +100,7 @@ Receiving a Message
 In order to read a message from a radio's receive buffer, call the ``k_radio_recv`` function.
 
 The function takes two parameters:
-- A pointer to a storage buffer where the message should be put
+- A pointer to a ``radio_rx_message`` structure where the message will be put
 - A pointer to a variable which will be updated to contain the length of the message received.
 
 The function will return one of three values:
@@ -116,7 +115,7 @@ For example:
     #include "radio-api/radio.h"
     
     KRadioStatus status;
-    uint8_t buffer[256];
+    radio_rx_message buffer;
     uint8_t len;
 
-    status = k_radio_recv(buffer, &len);
+    status = k_radio_recv(&buffer, &len);

--- a/docs/device-api/radio.rst
+++ b/docs/device-api/radio.rst
@@ -73,11 +73,13 @@ Sending a Message
 In order to write a message to the radio's transmit buffer, call the ``k_radio_send`` function.
 
 The function takes three parameters:
+
 - A pointer to the message to be sent
 - The length of the message
 - A pointer to a response byte (varies by radio. For example, returning the number of bytes written)
 
 The function will return one of two values:
+
 - RADIO_OK - Indicating a message was successfully received
 - RADIO_ERROR - Indicating that something went wrong during the send process
 
@@ -100,10 +102,12 @@ Receiving a Message
 In order to read a message from a radio's receive buffer, call the ``k_radio_recv`` function.
 
 The function takes two parameters:
+
 - A pointer to a ``radio_rx_message`` structure where the message will be put
 - A pointer to a variable which will be updated to contain the length of the message received.
 
 The function will return one of three values:
+
 - RADIO_OK - Indicating a message was successfully received
 - RADIO_RX_EMPTY - Indicating there are no messages to receive
 - RADIO_ERROR - Indicating that something went wrong during the receive process

--- a/docs/device-api/radio_api.rst
+++ b/docs/device-api/radio_api.rst
@@ -4,5 +4,8 @@
 Kubos Radio API
 ===============
 
+.. doxygenfile:: radio-struct.h
+    :project: kubos-radio-api
+    
 .. doxygenfile:: radio.h
     :project: kubos-radio-api

--- a/radio/radio-api/radio-api/radio-struct.h
+++ b/radio/radio-api/radio-api/radio-struct.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2017 Kubos Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Global Radio Structures/Enumerators
+ */
+/**
+ * @addtogroup radio
+ * @{
+ */
+
+/**
+ * Radio function return values
+ */
+typedef enum {
+    /** Function call completed successfully */
+    RADIO_OK = 0,
+    /** Radio receive buffer is empty */
+    RADIO_RX_EMPTY,
+    /** Generic radio error */
+    RADIO_ERROR,
+    /** Function input parameter is invalid */
+    RADIO_ERROR_CONFIG
+} KRadioStatus;
+
+/**
+ * Radio reset types
+ */
+typedef enum {
+    /** Perform hardware-level radio reset */
+    RADIO_HARD_RESET,
+    /** Perform software radio reset */
+    RADIO_SOFT_RESET
+} KRadioReset;
+
+/**
+ * AX.25 call-sign structure
+ */
+typedef struct
+{
+    /**
+     * Six character station call-sign
+     */
+    uint8_t ascii[6];
+    /**
+     * One byte station SSID value
+     */
+    uint8_t ssid;
+} ax25_callsign;

--- a/radio/radio-api/radio-api/radio-struct.h
+++ b/radio/radio-api/radio-api/radio-struct.h
@@ -58,3 +58,4 @@ typedef struct
      */
     uint8_t ssid;
 } ax25_callsign;
+/* @} */

--- a/radio/radio-api/radio-api/radio.h
+++ b/radio/radio-api/radio-api/radio.h
@@ -25,17 +25,6 @@
 #include "radio-struct.h"
 #include "radio-impl.h"
 
-/* Define the radio-specific structures/enumerators */
-/*
-#if defined(YOTTA_CFG_RADIO_TRXVU) && !defined(HAVE_RADIO)
-#define HAVE_RADIO
-#include <trxvu-radio-api/radio.h>
-#endif
-#ifndef HAVE_RADIO
-#error No radio defined!
-#endif
-*/
-
 /* Define the global functions */
 /**
  * Initialize the radio interface

--- a/radio/radio-api/radio-api/radio.h
+++ b/radio/radio-api/radio-api/radio.h
@@ -22,51 +22,15 @@
 #pragma once
 
 #include <stdint.h>
-
-/* Define the global structures/enumerators */
-/**
- * Radio function return values
- */
-typedef enum {
-    /** Function call completed successfully */
-    RADIO_OK = 0,
-    /** Radio receive buffer is empty */
-    RADIO_RX_EMPTY,
-    /** Generic radio error */
-    RADIO_ERROR,
-    /** Function input parameter is invalid */
-    RADIO_ERROR_CONFIG
-} KRadioStatus;
-
-/**
- * Radio reset types
- */
-typedef enum {
-    /** Perform hardware-level radio reset */
-    RADIO_HARD_RESET,
-    /** Perform software radio reset */
-    RADIO_SOFT_RESET
-} KRadioReset;
-
-/**
- * AX.25 call-sign structure
- */
-typedef struct
-{
-    /**
-     * Six character station call-sign
-     */
-    uint8_t ascii[6];
-    /**
-     * One byte station SSID value
-     */
-    uint8_t ssid;
-} ax25_callsign;
+#include "radio-struct.h"
 
 /* Define the radio-specific structures/enumerators */
 #if defined(YOTTA_CFG_RADIO_TRXVU) && !defined(HAVE_RADIO)
 #define HAVE_RADIO
 #include <trxvu-radio-api/radio.h>
+#endif
+#ifndef HAVE_RADIO
+#error No radio defined!
 #endif
 
 /* Define the global functions */

--- a/radio/radio-api/radio-api/radio.h
+++ b/radio/radio-api/radio-api/radio.h
@@ -23,6 +23,7 @@
 
 #include <stdint.h>
 
+/* Define the global structures/enumerators */
 /**
  * Radio function return values
  */
@@ -62,6 +63,13 @@ typedef struct
     uint8_t ssid;
 } ax25_callsign;
 
+/* Define the radio-specific structures/enumerators */
+#if defined(YOTTA_CFG_RADIO_TRXVU) && !defined(HAVE_RADIO)
+#define HAVE_RADIO
+#include <trxvu-radio-api/radio.h>
+#endif
+
+/* Define the global functions */
 /**
  * Initialize the radio interface
  * @return KRadioStatus RADIO_OK if OK, error otherwise
@@ -74,10 +82,10 @@ void k_radio_terminate(void);
 /**
  * Configure the radio
  * @note This function might not be implemented for all radios. See specific radio API documentation for configuration availability and structure
- * @param [in] radio_config Pointer to the radio configuration structure
+ * @param [in] config Pointer to the radio configuration structure
  * @return KRadioStatus RADIO_OK if OK, error otherwise
  */
-KRadioStatus k_radio_configure(uint8_t * radio_config);
+KRadioStatus k_radio_configure(radio_config * config);
 /**
  * Reset the radio
  * @note This function might not be implemented for all radios
@@ -99,7 +107,7 @@ KRadioStatus k_radio_send(char * buffer, int len, uint8_t * response);
  * @param [out] len Length of the received message
  * @return KRadioStatus RADIO_OK if a message was received successfully, RADIO_RX_EMPTY if there are no messages to receive, error otherwise
  */
-KRadioStatus k_radio_recv(char * buffer, uint8_t * len);
+KRadioStatus k_radio_recv(radio_rx_message * buffer, uint8_t * len);
 /**
  * Read radio telemetry values
  * @note See specific radio API documentation for available telemetry types
@@ -107,6 +115,6 @@ KRadioStatus k_radio_recv(char * buffer, uint8_t * len);
  * @param [in] type Telemetry packet to read
  * @return KRadioStatus RADIO_OK if OK, error otherwise
  */
-KRadioStatus k_radio_get_telemetry(uint8_t * buffer, uint8_t type);
+KRadioStatus k_radio_get_telemetry(radio_telem * buffer, RadioTelemType type);
 
 /* @} */

--- a/radio/radio-api/radio-api/radio.h
+++ b/radio/radio-api/radio-api/radio.h
@@ -23,8 +23,10 @@
 
 #include <stdint.h>
 #include "radio-struct.h"
+#include "radio-impl.h"
 
 /* Define the radio-specific structures/enumerators */
+/*
 #if defined(YOTTA_CFG_RADIO_TRXVU) && !defined(HAVE_RADIO)
 #define HAVE_RADIO
 #include <trxvu-radio-api/radio.h>
@@ -32,6 +34,7 @@
 #ifndef HAVE_RADIO
 #error No radio defined!
 #endif
+*/
 
 /* Define the global functions */
 /**


### PR DESCRIPTION
Passing generic pointers is bad. Passing pointers to context-specific structures is better.

Updating the generic radio API to include the appropriate specific radio API based on the `config.json` file so that quasi-generic radio structures can be used instead of generic pointers.

The TRXVU API will also be updated to reflect these changes.