### PR TITLE
Changed release tagging script to use semver compliant build numbers.

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -8,7 +8,7 @@ echo "Latest tag: $latest_tag"
 #Stable releases follow major.minor.patch version format
 major_regex='^[0-9]+\.[0-9]+\.[0-9]$'
 #Unstable (CD) releases follow major.minor.patch.build version format
-build_regex='^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$'
+build_regex='^[0-9]+\.[0-9]+\.[0-9]+\+[0-9]+$'
 
 if [[ $latest_tag =~ $major_regex ]];
 then
@@ -23,7 +23,7 @@ then
     v_patch=${version_list[2]}
     v_build=${version_list[3]}
     ((v_build+=1))
-    new_tag="$v_major.$v_minor.$v_patch.$v_build"
+    new_tag="$v_major.$v_minor.$v_patch+$v_build"
 fi
 
 echo "Tagging new verson: $new_tag"


### PR DESCRIPTION
Currently we are producing release builds with the version format `major.minor.patch.build`. This is not quite compliant with how semantic versioning expects build numbers to be presented and causes issues when uploading docs for releases with a build number. PR changes format to `major.minor.patch+build`.